### PR TITLE
reference sdk repos using public URL in playbook

### DIFF
--- a/production-antora-playbook.yml
+++ b/production-antora-playbook.yml
@@ -33,14 +33,14 @@ content:
     start_path: docs
   # NOTE server-docs is currently after other server repos so nav key wins
   - url: https://github.com/couchbase/docs-server.git
-  - url: git@github.com:couchbase/docs-sdk-common.git
-  - url: git@github.com:couchbase/docs-sdk-c.git
-  - url: git@github.com:couchbase/docs-sdk-dotnet.git
-  - url: git@github.com:couchbase/docs-sdk-go.git
-  - url: git@github.com:couchbase/docs-sdk-java.git
-  - url: git@github.com:couchbase/docs-sdk-nodejs.git
-  - url: git@github.com:couchbase/docs-sdk-php.git
-  - url: git@github.com:couchbase/docs-sdk-python.git
+  - url: https://github.com/couchbase/docs-sdk-common.git
+  - url: https://github.com/couchbase/docs-sdk-c.git
+  - url: https://github.com/couchbase/docs-sdk-dotnet.git
+  - url: https://github.com/couchbase/docs-sdk-go.git
+  - url: https://github.com/couchbase/docs-sdk-java.git
+  - url: https://github.com/couchbase/docs-sdk-nodejs.git
+  - url: https://github.com/couchbase/docs-sdk-php.git
+  - url: https://github.com/couchbase/docs-sdk-python.git
   - url: https://github.com/couchbaselabs/docs-couchbase-lite.git
     branches: [master, release/2.0, release/1.4]
   - url: https://github.com/couchbaselabs/docs-sync-gateway.git

--- a/staging-antora-playbook.yml
+++ b/staging-antora-playbook.yml
@@ -31,14 +31,14 @@ content:
     start_path: docs
   # NOTE server-docs is currently after other server repos so nav key wins
   - url: https://github.com/couchbase/docs-server.git
-  - url: git@github.com:couchbase/docs-sdk-common.git
-  - url: git@github.com:couchbase/docs-sdk-c.git
-  - url: git@github.com:couchbase/docs-sdk-dotnet.git
-  - url: git@github.com:couchbase/docs-sdk-go.git
-  - url: git@github.com:couchbase/docs-sdk-java.git
-  - url: git@github.com:couchbase/docs-sdk-nodejs.git
-  - url: git@github.com:couchbase/docs-sdk-php.git
-  - url: git@github.com:couchbase/docs-sdk-python.git
+  - url: https://github.com/couchbase/docs-sdk-common.git
+  - url: https://github.com/couchbase/docs-sdk-c.git
+  - url: https://github.com/couchbase/docs-sdk-dotnet.git
+  - url: https://github.com/couchbase/docs-sdk-go.git
+  - url: https://github.com/couchbase/docs-sdk-java.git
+  - url: https://github.com/couchbase/docs-sdk-nodejs.git
+  - url: https://github.com/couchbase/docs-sdk-php.git
+  - url: https://github.com/couchbase/docs-sdk-python.git
   - url: https://github.com/couchbaselabs/docs-couchbase-lite.git
     branches: [master, release/2.0, release/1.4]
   - url: https://github.com/couchbaselabs/docs-sync-gateway.git


### PR DESCRIPTION
The convention is that any repository that is public should be accessed via HTTPS, whereas any repository that is private should be accessed via SSH. This is also how the UI determines whether to offer an edit on GitHub button.