### PR TITLE
update Couchbase Lite branches and include release/2.5 in staging playbook.

### DIFF
--- a/production-antora-playbook.yml
+++ b/production-antora-playbook.yml
@@ -42,7 +42,7 @@ content:
   - url: https://github.com/couchbase/docs-sdk-php.git
   - url: https://github.com/couchbase/docs-sdk-python.git
   - url: https://github.com/couchbaselabs/docs-couchbase-lite.git
-    branches: [master, release/2.0, release/1.4, release/1.3]
+    branches: [release/2.1, release/2.0, release/1.4, release/1.3]
   - url: https://github.com/couchbaselabs/docs-sync-gateway.git
     branches: [release/2.1, release/2.0, release/1.5, release/1.4, release/1.3]
 asciidoc:

--- a/staging-antora-playbook.yml
+++ b/staging-antora-playbook.yml
@@ -40,7 +40,7 @@ content:
   - url: https://github.com/couchbase/docs-sdk-php.git
   - url: https://github.com/couchbase/docs-sdk-python.git
   - url: https://github.com/couchbaselabs/docs-couchbase-lite.git
-    branches: [master, release/2.0, release/1.4, release/1.3]
+    branches: [release/2.5, release/2.1, release/2.0, release/1.4, release/1.3]
   - url: https://github.com/couchbaselabs/docs-sync-gateway.git
     branches: [release/2.5, release/2.1, release/2.0, release/1.5, release/1.4, release/1.3]
 asciidoc:


### PR DESCRIPTION
update Couchbase Lite branches and include release/2.5 in staging playbook.