### PR TITLE
example to group code blocks

### DIFF
--- a/home/modules/contribute/examples/code-blocks.adoc
+++ b/home/modules/contribute/examples/code-blocks.adoc
@@ -51,3 +51,25 @@ function OnUpdate(doc, meta) {
 <3> Stream results using 'for' iterator.
 <4> Cancel streaming query by breaking out.
 // end::callouts[]
+
+// tag::group-code-blocks[]
+====
+[source,n1ql]
+----
+SELECT CONTAINS("N1QL is awesome", "N1QL") as n1ql,
+       CONTAINS("N1QL is awesome", "SQL") as no_sql;
+----
+
+[source,json]
+----
+{
+    "results": [
+        {
+            "n1ql": true,
+            "no_sql": false
+        }
+    ]
+}
+----
+====
+// end::group-code-blocks[]

--- a/home/modules/contribute/pages/code-blocks.adoc
+++ b/home/modules/contribute/pages/code-blocks.adoc
@@ -46,6 +46,16 @@ Rendered as:
 
 include::example$code-blocks.adoc[tag=single]
 
+Code blocks can be grouped in a parent block element.
+
+....
+include::example$code-blocks.adoc[tag=group-code-blocks]
+....
+
+Rendered as:
+
+include::example$code-blocks.adoc[tag=group-code-blocks]
+
 [#callouts]
 == Callout Numbers
 


### PR DESCRIPTION
renders as

![upload_thumb](https://user-images.githubusercontent.com/2589337/49606757-19e55e00-f98c-11e8-850c-423e0cfccf1a.png)

Kudos to @eric-schneider and @simon-dew for starting this out.