### PR TITLE
Update staging playbook with new Operator branch

### DIFF
--- a/staging-antora-playbook.yml
+++ b/staging-antora-playbook.yml
@@ -9,7 +9,7 @@ content:
     branches: HEAD
     start_path: home
   - url: git@github.com:couchbase/couchbase-operator.git
-    branches: [master, 1.1.x, 1.0.x]
+    branches: [master, 1.2.x, 1.1.x, 1.0.x]
     start_path: docs/user
   - url: https://github.com/couchbase/couchbase-elasticsearch-connector.git
     branches: [release/4.0, release/cypress]


### PR DESCRIPTION
This commit updates the staging playbook with the new Operator 1.2.x branch. Before this PR can be merged, antora.yml on the master branch in the Operator repo needs to be updated to a newer version, otherwise the build will fail. That change is staged in Gerrit.