### PR TITLE
DOC-4138 - Tutorials version dropdown

### DIFF
--- a/production-antora-playbook.yml
+++ b/production-antora-playbook.yml
@@ -93,7 +93,7 @@ asciidoc:
   - ./lib/tabs-block.js
 ui:
   bundle:
-    url: https://github.com/couchbase/docs-ui/releases/download/v214/ui-bundle.zip
+    url: https://github.com/couchbase/docs-ui/releases/download/v216/ui-bundle.zip
   supplemental_files:
   - path: robots.txt
     contents: |

--- a/staging-antora-playbook.yml
+++ b/staging-antora-playbook.yml
@@ -90,8 +90,7 @@ asciidoc:
   - ./lib/tabs-block.js
 ui:
   bundle:
-    url: https://deploy-preview-58--cb-docs-ui.netlify.com/dist/ui-bundle.zip
-    snapshot: true
+    url: https://github.com/couchbase/docs-ui/releases/download/v216/ui-bundle.zip
   supplemental_files:
   - path: robots.txt
     contents: |

--- a/staging-antora-playbook.yml
+++ b/staging-antora-playbook.yml
@@ -90,7 +90,8 @@ asciidoc:
   - ./lib/tabs-block.js
 ui:
   bundle:
-    url: https://github.com/couchbase/docs-ui/releases/download/v214/ui-bundle.zip
+    url: https://deploy-preview-58--cb-docs-ui.netlify.com/dist/ui-bundle.zip
+    snapshot: true
   supplemental_files:
   - path: robots.txt
     contents: |


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-4138

docs-ui v216 contains:

- a fix for to remove the "View Latest" banner tutorials.
  Example:
  https://deploy-preview-91--cb-docs-staging.netlify.com/userprofile-couchbase-mobile/standalone/userprofile/userprofile_basic.html
  https://deploy-preview-91--cb-docs-staging.netlify.com/userprofile-couchbase-mobile/query/userprofile/userprofile_query.html
  (known issue: the banner is still visible on the Android and Xamarin tutorials, I will add the page attribute there after this PR is merged).
- a fix to remove the version dropdown on the `tutorials` and `userprofile-couchbase-mobile` components and show a link to the tutorials home page instead.
  Example:
https://deploy-preview-91--cb-docs-staging.netlify.com/tutorials/session-storage/install.html
  etc.