### PR TITLE
Dev preview partial

### DIFF
--- a/home/modules/ROOT/partials/developer-preview.adoc
+++ b/home/modules/ROOT/partials/developer-preview.adoc
@@ -1,0 +1,6 @@
+[CAUTION]
+--
+This is a Developer Preview feature, intended for development purposes only.
+Do not use this feature in production.
+No Enterprise Support is provided for Developer Preview features.
+--

--- a/home/modules/contribute/examples/developer-preview.adoc
+++ b/home/modules/contribute/examples/developer-preview.adoc
@@ -1,0 +1,1 @@
+include:home:ROOT:partial$developer-preview.adoc[]

--- a/home/modules/contribute/pages/includes.adoc
+++ b/home/modules/contribute/pages/includes.adoc
@@ -105,6 +105,21 @@ For example, if you tag code in a YAML file, place a hash (`+#+`) before the tag
     - public/
 ----
 
+== Couchbase Documentation Partials
+
+=== Developer Preview Partial
+
+To call out a section of a page as Developer Preview, use the `developer-preview` partial.
+Otherwise if the whole page is Developer Preview content, you can use the xref:attributes-and-roles.adoc#custom-page-attributes[page-status] attribute.
+
+----
+\include::home:ROOT:partial$developer-preview.adoc[]
+----
+
+Renders as:
+
+include::home:ROOT:partial$developer-preview.adoc[]
+
 == Learn More
 
 * xref:code-blocks.adoc#include-code[Insert examples into code blocks with the include directive].


### PR DESCRIPTION
Follow up from @simon-dew's commit [27cad2b](https://github.com/couchbase/docs-server/commit/ab6d3eafa331bb66a04f87b28281a0837517e4a4#diff-27cad2b57b742b638d75023b6acfe0ff) which adds a partial in the `server` component.

This PR adds a slightly modified version of that partial to the `ROOT` module in the `home` component and documents a usage example.

I've removed the h2 and xref to the developer preview mode page (specific to CB Server) although we could certainly add those back in in a sub-sequent PR with their respective usage examples.

Preview: https://deploy-preview-109--cb-docs-staging.netlify.com/home/contribute/includes.html#couchbase-documentation-partials