### PR TITLE
Release Elasticsearch 4.1 documentation

### DIFF
--- a/production-antora-playbook.yml
+++ b/production-antora-playbook.yml
@@ -14,7 +14,7 @@ content:
     branches: [1.2.x, 1.1.x, 1.0.x]
     start_path: docs/user
   - url: https://github.com/couchbase/couchbase-elasticsearch-connector.git
-    branches: [release/4.0, release/cypress]
+    branches: [master, release/4.0, release/cypress]
     start_path: docs
   - url: https://github.com/couchbase/kafka-connect-couchbase.git
     branches: [master, release/3.3]

--- a/staging-antora-playbook.yml
+++ b/staging-antora-playbook.yml
@@ -12,7 +12,7 @@ content:
     branches: [master, 1.2.x, 1.1.x, 1.0.x]
     start_path: docs/user
   - url: https://github.com/couchbase/couchbase-elasticsearch-connector.git
-    branches: [release/4.0, release/cypress]
+    branches: [master, release/4.0, release/cypress]
     start_path: docs
   - url: https://github.com/couchbase/kafka-connect-couchbase.git
     branches: [master, release/3.3]


### PR DESCRIPTION
Publish docs for Elasticsearch connector 4.1.x from the master branch.