### PR TITLE
Get Elasticsearch connector 4.1 docs from branch `release/4.1`

### DIFF
--- a/production-antora-playbook.yml
+++ b/production-antora-playbook.yml
@@ -14,7 +14,7 @@ content:
     branches: [1.2.x, 1.1.x, 1.0.x]
     start_path: docs/user
   - url: https://github.com/couchbase/couchbase-elasticsearch-connector.git
-    branches: [master, release/4.0, release/cypress]
+    branches: [release/4.1, release/4.0, release/cypress]
     start_path: docs
   - url: https://github.com/couchbase/kafka-connect-couchbase.git
     branches: [master, release/3.3]

--- a/staging-antora-playbook.yml
+++ b/staging-antora-playbook.yml
@@ -106,3 +106,4 @@ ui:
 output:
   dir: ./public
 
+

--- a/staging-antora-playbook.yml
+++ b/staging-antora-playbook.yml
@@ -106,4 +106,3 @@ ui:
 output:
   dir: ./public
 
-

--- a/staging-antora-playbook.yml
+++ b/staging-antora-playbook.yml
@@ -12,7 +12,7 @@ content:
     branches: [master, 1.2.x, 1.1.x, 1.0.x]
     start_path: docs/user
   - url: https://github.com/couchbase/couchbase-elasticsearch-connector.git
-    branches: [master, release/4.0, release/cypress]
+    branches: [release/4.1, release/4.0, release/cypress]
     start_path: docs
   - url: https://github.com/couchbase/kafka-connect-couchbase.git
     branches: [master, release/3.3]


### PR DESCRIPTION
Master branch is now 4.2, so 4.1 docs need to come from `release/4.1`.