### PR TITLE
Update for Elasticsearch connector 4.2

### DIFF
--- a/etc/nginx/snippets/rewrites.conf
+++ b/etc/nginx/snippets/rewrites.conf
@@ -4,7 +4,7 @@ set $current_version_server '6.0';
 set $current_version_operator '1.2';
 set $current_version_couchbase_lite '2.6';
 set $current_version_sync_gateway '2.6';
-set $current_version_connector_elasticsearch '4.1';
+set $current_version_connector_elasticsearch '4.2';
 set $current_version_connector_kafka '3.4';
 set $current_version_connector_spark '2.4';
 set $current_version_sdk_c '2.10';

--- a/production-antora-playbook.yml
+++ b/production-antora-playbook.yml
@@ -14,7 +14,7 @@ content:
     branches: [1.2.x, 1.1.x, 1.0.x]
     start_path: docs/user
   - url: https://github.com/couchbase/couchbase-elasticsearch-connector.git
-    branches: [master, release/4.0, release/cypress]
+    branches: [master, release/4.1, release/4.0, release/cypress]
     start_path: docs
   - url: https://github.com/couchbase/kafka-connect-couchbase.git
     branches: [master, release/3.3]

--- a/staging-antora-playbook.yml
+++ b/staging-antora-playbook.yml
@@ -12,7 +12,7 @@ content:
     branches: [master, 1.2.x, 1.1.x, 1.0.x]
     start_path: docs/user
   - url: https://github.com/couchbase/couchbase-elasticsearch-connector.git
-    branches: [master, release/4.0, release/cypress]
+    branches: [master, release/4.1, release/4.0, release/cypress]
     start_path: docs
   - url: https://github.com/couchbase/kafka-connect-couchbase.git
     branches: [master, release/3.3]


### PR DESCRIPTION
Modifications
-------------
Get Elasticsearch connector 4.1 docs from branch `release/4.1`.

Get 4.2 docs from branch `master`.

Update current version to 4.2.