### PR TITLE
DOC-6341-Add link to a couchbase mobile landing page

### DIFF
--- a/home/modules/ROOT/pages/index.adoc
+++ b/home/modules/ROOT/pages/index.adoc
@@ -61,7 +61,7 @@ If you are a Couchbase user wanting to develop for applications on the edge
 * xref:server:sdk:overview.adoc[SDKs]
 
 [.tile]
-.Couchbase Mobile
+.xref:sync-gateway::cbmintro.adoc[Couchbase Mobile]
 * xref:couchbase-lite::index.adoc[Lite]
 * xref:sync-gateway::index.adoc[Sync Gateway]
 


### PR DESCRIPTION
Add in an additional link to Couchbase Mobile from the Docs page, namely:
link to the :sync-gateway::cbmintro.adoc page, which acts as a shared Couchbase Mobile landing-page accessible from SGW and, eventually, CBL.