### PR TITLE
Replace Operator master branch with 2.0.x branch

### DIFF
--- a/production-antora-playbook.yml
+++ b/production-antora-playbook.yml
@@ -12,7 +12,7 @@ content:
     branches: HEAD
     start_path: home
   - url: https://git@github.com/couchbase/couchbase-operator.git
-    branches: [master, 1.2.x, 1.1.x, 1.0.x]
+    branches: [2.0.x, 1.2.x, 1.1.x, 1.0.x]
     start_path: docs/user
   - url: https://github.com/couchbase/couchbase-elasticsearch-connector.git
     branches: [master, release/4.1, release/4.0, release/cypress]


### PR DESCRIPTION
For AO, replaced master branch with the 2.0.x branch.