### PR TITLE
Add Operator 2.0.x branch to staging

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -13,7 +13,7 @@ content:
     branches: HEAD
     start_path: home
   - url: https://git@github.com/couchbase/couchbase-operator
-    branches: [master, 1.2.x, 1.1.x, 1.0.x]
+    branches: [master, 2.0.x, 1.2.x, 1.1.x, 1.0.x]
     start_path: docs/user
   - url: https://github.com/couchbase/couchbase-elasticsearch-connector
     branches: [master, release/4.1, release/4.0, release/cypress]


### PR DESCRIPTION
For AO, add 2.0.x branch, as master will now carry forward minor releases.