### PR TITLE
Build Kafka 3.4 docs from release/3.4 branch

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -22,7 +22,7 @@ content:
     branches: [master, release/4.1, release/4.0, release/cypress]
     start_path: docs
   - url: https://github.com/couchbase/kafka-connect-couchbase
-    branches: [master, release/3.3]
+    branches: [release/3.4, release/3.3]
     start_path: docs
   - url: https://github.com/couchbase/couchbase-spark-connector
     branches: [master, release/2.3, release/2.2, release/2.1]


### PR DESCRIPTION
Motivation
----------
master branch is now being used for 4.0 development