### PR TITLE
DOC-7395: Use cb-swagger repo for REST API doc partials

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -38,6 +38,9 @@ content:
   - url: https://git@github.com/couchbase/backup
     branches: [mad-hatter, 6.5.x-docs, alice, vulcan, spock, 5.0.x]
     start_path: docs
+  - url: https://github.com/couchbaselabs/cb-swagger
+    branches: [release/6.6, release/6.5, release/6.0]
+    start_path: docs
   # NOTE docs-server is currently after other server repos so nav key wins
   - url: https://github.com/couchbase/docs-server
     branches: [release/6.6, release/6.5, release/6.0, release/5.5, release/5.1, release/5.0]


### PR DESCRIPTION
Add cb-swagger repo for REST API documentation. (This won't work until all related changes have been merged in the `docs-server` repo, for branches `release/6.0`, `release/6.5` and `release/6.6`.)

Docs issue: [DOC-7395](https://issues.couchbase.com/browse/DOC-7395)