### PR TITLE
DOC-7395: Use cb-swagger repo for REST API doc partials

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -36,6 +36,9 @@ content:
   - url: https://git@github.com/couchbase/backup
     branches: [master, mad-hatter, 6.5.x-docs, alice, vulcan, spock, 5.0.x]
     start_path: docs
+  - url: https://github.com/couchbaselabs/cb-swagger
+    branches: [release/6.6, release/6.5, release/6.0]
+    start_path: docs
   # NOTE docs-server is currently after other server repos so nav key wins
   - url: https://github.com/couchbase/docs-server
     branches: [release/7.0, release/6.6, release/6.5, release/6.0, release/5.5, release/5.1, release/5.0]


### PR DESCRIPTION
Add cb-swagger repo for REST API documentation. Port of #278 to staging.

Docs issue: [DOC-7395](https://issues.couchbase.com/browse/DOC-7395)