### PR TITLE
Bump UI bundle version for fixes

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -127,6 +127,6 @@ asciidoc:
   - ./lib/tabs-block.js
 ui:
   bundle:
-    url: https://github.com/couchbase/docs-ui-sandbox/releases/download/prod-84/ui-bundle.zip
+    url: https://github.com/couchbase/docs-ui-sandbox/releases/download/prod-86/ui-bundle.zip
 output:
   dir: ./public


### PR DESCRIPTION
- Update top banner: Move link to .com to icon, update label from Try Now to Downloads, 
- Add home icon to top (blue) menu
- Fix anchor ids not resolving on Chrome
- Update code block highlighting colors for yellow and light grey