### PR TITLE
SBEE-32: Move CSB 1.0 to its own branch

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -84,7 +84,7 @@ content:
   - url: https://github.com/couchbaselabs/docs-sync-gateway
     branches: [release/2.8, release/2.7, release/2.6, release/2.5, release/2.1, release/2.0, release/1.5]
   - url: https://github.com/couchbase/docs-service-broker.git
-    branches: [master]
+    branches: [1.0.x]
   - url: https://github.com/couchbase/docs-cloud-native.git
     branches: [master]
   - url: https://github.com/couchbaselabs/tutorials


### PR DESCRIPTION
WARNING! The following PR must be merged first:
- https://github.com/couchbase/docs-site/pull/354


[SBEE-32](https://issues.couchbase.com/browse/SBEE-32)

Now that we've [branched](https://github.com/couchbase/docs-service-broker/tree/1.0.x) the 1.0 release of `docs-service-broker`, we need to update the prod docs site to point to this new branch so that we can begin adding CSB 1.1 content to master.

NOTE: The immediate next step will be to [update `antora.yml` to version `1.1`](https://github.com/couchbase/docs-service-broker/blob/master/antora.yml#L3) on the master. After that, we can update the docs-staging playbook to include both `master` and `1.0.x` branches.