### PR TITLE
SBEE-32: Move CSB 1.0 to its own branch (staging)

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -75,7 +75,7 @@ content:
   - url: https://github.com/couchbaselabs/docs-sync-gateway
     branches: [release/3.0, release/2.8, release/2.7, release/2.6, release/2.5, release/2.1, release/2.0, release/1.5]
   - url: https://github.com/couchbase/docs-service-broker.git
-    branches: [master]
+    branches: [1.0.x]
   - url: https://github.com/couchbase/docs-cloud-native.git
     branches: [cndp-nav]
   - url: https://git@github.com/couchbase/docs-ngdm


### PR DESCRIPTION
[SBEE-32](https://issues.couchbase.com/browse/SBEE-32)

Now that we've [branched](https://github.com/couchbase/docs-service-broker/tree/1.0.x) the 1.0 release of `docs-service-broker`, we need to update the staging docs site to point to this new branch so that we can begin adding CSB 1.1 content to master.