### PR TITLE
Service Broker: Update staging to match production

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -77,7 +77,7 @@ content:
   - url: https://github.com/couchbaselabs/docs-sync-gateway
     branches: [release/3.0, release/2.8, release/2.7, release/2.6, release/2.5, release/2.1, release/2.0, release/1.5]
   - url: https://github.com/couchbase/docs-service-broker.git
-    branches: [master, 1.0.x]
+    branches: [1.1.x, 1.0.x]
   - url: https://git@github.com/couchbase/docs-cloud-native.git
     branches: [cloud-native-2.2]
   - url: https://git@github.com/couchbase/docs-ngdm


### PR DESCRIPTION
Since there has been no declared version for the next release of the Couchbase Service Broker, I've gone ahead and matched the branches in the staging playbook with those in the production playbook. I will add master back to the staging playbook once a plan is in place for the next CSB release. Until then, removing master from the staging playbook reduces the risk of failed builds.