### PR TITLE
Update UI to v127 for language highlighting changes

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -149,6 +149,6 @@ asciidoc:
   - ./lib/tabs-block.js
 ui:
   bundle:
-    url: https://github.com/couchbase/docs-ui/releases/download/prod-124/ui-bundle.zip
+    url: https://github.com/couchbase/docs-ui/releases/download/prod-127/ui-bundle.zip
 output:
   dir: ./public


### PR DESCRIPTION
Update the UI bundle to support language highlighting for the `nodejs` alias and the addition of `typescript`.