### PR TITLE
upgrade UI to fix width of search results between 769px and 1024px

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -147,6 +147,6 @@ asciidoc:
   - ./lib/tabs-block.js
 ui:
   bundle:
-    url: https://github.com/couchbase/docs-ui/releases/download/prod-132/ui-bundle.zip
+    url: https://github.com/couchbase/docs-ui/releases/download/prod-133/ui-bundle.zip
 output:
   dir: ./public


### PR DESCRIPTION
Sets the minimum width of the search results to 50vw so it doesn't shrink when the screen width is between 769px and 1024px.