### PR TITLE
Update to docs-ui bundle 135

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -147,6 +147,6 @@ asciidoc:
   - ./lib/tabs-block.js
 ui:
   bundle:
-    url: https://github.com/couchbase/docs-ui/releases/download/prod-133/ui-bundle.zip
+    url: https://github.com/couchbase/docs-ui/releases/download/prod-135/ui-bundle.zip
 output:
   dir: ./public


### PR DESCRIPTION
This adds :page-toclevels: support.