### PR TITLE
tail antora log on failure

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -47,21 +47,21 @@ content:
     start_path: docs
   - url: https://git@github.com/couchbase/docs-connectors-talend
   - url: https://git@github.com/couchbase/docs-analytics
-    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0, release/5.5]
+    branches: [release/7.0, release/6.6, release/6.5, release/6.0, release/5.5]
   - url: https://github.com/couchbase/couchbase-cli
-    branches: [master, cheshire-cat, mad-hatter, 6.5.x-docs, alice, vulcan, spock, 5.0.1]
+    branches: [cheshire-cat, mad-hatter, 6.5.x-docs, alice, vulcan, spock, 5.0.1]
     start_path: docs
   - url: https://git@github.com/couchbase/backup
-    branches: [master, cheshire-cat, mad-hatter, 6.5.x-docs, alice, vulcan, spock, 5.0.x]
+    branches: [cheshire-cat, mad-hatter, 6.5.x-docs, alice, vulcan, spock, 5.0.x]
     start_path: docs
   - url: https://github.com/couchbaselabs/cb-swagger
-    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0]
+    branches: [release/7.0, release/6.6, release/6.5, release/6.0]
     start_path: docs
   # NOTE docs-server is currently after other server repos so nav key wins
   - url: https://github.com/couchbase/docs-server
-    branches: [release/7.1, dev-reorg, release/7.0, release/6.6, release/6.5, release/6.0, release/5.5, release/5.1, release/5.0]
+    branches: [dev-reorg, release/7.0, release/6.6, release/6.5, release/6.0, release/5.5, release/5.1, release/5.0]
   - url: https://github.com/couchbase/docs-sdk-common
-    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0, release/5.5]
+    branches: [release/7.0, release/6.6, release/6.5, release/6.0, release/5.5]
   - url: https://github.com/couchbase/docs-sdk-c
     branches: [release/3.2, release/3.1, release/3.0, release/2.10]
   - url: https://github.com/couchbase/docs-txn-cxx

--- a/netlify/netlify.toml
+++ b/netlify/netlify.toml
@@ -5,10 +5,10 @@ if [ -v FONTAWESOME_NPM_TOKEN ]; then echo -e '@fortawesome:registry=https://npm
 (cd ../scripts; npm --no-package-lock i >/dev/null || true); \
 if [ -v GITHUB_TOKEN ]; then export GIT_CREDENTIALS=https://$GITHUB_TOKEN:@github.com; else node ../scripts/remove-private-content-sources.js ../antora-playbook.yml; fi; \
 touch antora.log; \
-time node_modules/.bin/antora --fetch --generator=@antora/site-generator-ms --attribute=site-navigation-data-path=_/js/site-navigation-data.js --redirect-facility=netlify --to-dir=public --url $(if [[ $CONTEXT == 'production' ]]; then echo -n $URL; else echo -n $DEPLOY_PRIME_URL; fi) ../antora-playbook.yml >antora.log 2>&1 || cat antora.log && \
+time node_modules/.bin/antora --fetch --generator=@antora/site-generator-ms --attribute=site-navigation-data-path=_/js/site-navigation-data.js --redirect-facility=netlify --to-dir=public --url $(if [[ $CONTEXT == 'production' ]]; then echo -n $URL; else echo -n $DEPLOY_PRIME_URL; fi) ../antora-playbook.yml >antora.log 2>&1 || tail antora.log && \
 node ../scripts/populate-icon-defs.js public && \
 mv antora.log public/ || \
-cat antora.log
+tail antora.log
 """
 #time node_modules/.bin/antora --fetch --generator=@antora/xref-validator ../antora-playbook.yml || true; \
 ignore = "false"


### PR DESCRIPTION
Cat seems to generate only ~920 lines of output, which is just 3%
of the 34,000 the local Netlify docker build image produces.