### PR TITLE
[NO ISSUE] build version 7.1 on staging site

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -59,7 +59,7 @@ content:
     start_path: docs
   # NOTE docs-server is currently after other server repos so nav key wins
   - url: https://github.com/couchbase/docs-server
-    branches: [release/7.1, dev-reorg, release/7.0, release/6.6, release/6.5, release/6.0]
+    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0]
   - url: https://github.com/couchbase/docs-sdk-common
     branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0]
   - url: https://github.com/couchbase/docs-sdk-c

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -47,21 +47,21 @@ content:
     start_path: docs
   - url: https://git@github.com/couchbase/docs-connectors-talend
   - url: https://git@github.com/couchbase/docs-analytics
-    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0, release/5.5]
+    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0]
   - url: https://github.com/couchbase/couchbase-cli
-    branches: [master, cheshire-cat, mad-hatter, 6.5.x-docs, alice, vulcan, spock, 5.0.1]
+    branches: [master, cheshire-cat, mad-hatter, 6.5.x-docs, alice]
     start_path: docs
   - url: https://git@github.com/couchbase/backup
-    branches: [master, cheshire-cat, mad-hatter, 6.5.x-docs, alice, vulcan, spock, 5.0.x]
+    branches: [master, cheshire-cat, mad-hatter, 6.5.x-docs, alice]
     start_path: docs
   - url: https://github.com/couchbaselabs/cb-swagger
     branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0]
     start_path: docs
   # NOTE docs-server is currently after other server repos so nav key wins
   - url: https://github.com/couchbase/docs-server
-    branches: [release/7.1, dev-reorg, release/7.0, release/6.6, release/6.5, release/6.0, release/5.5, release/5.1, release/5.0]
+    branches: [release/7.1, dev-reorg, release/7.0, release/6.6, release/6.5, release/6.0]
   - url: https://github.com/couchbase/docs-sdk-common
-    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0, release/5.5]
+    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0]
   - url: https://github.com/couchbase/docs-sdk-c
     branches: [release/3.2, release/3.1, release/3.0, release/2.10]
   - url: https://github.com/couchbase/docs-txn-cxx

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -47,21 +47,21 @@ content:
     start_path: docs
   - url: https://git@github.com/couchbase/docs-connectors-talend
   - url: https://git@github.com/couchbase/docs-analytics
-    branches: [release/7.0, release/6.6, release/6.5, release/6.0, release/5.5]
+    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0, release/5.5]
   - url: https://github.com/couchbase/couchbase-cli
-    branches: [cheshire-cat, mad-hatter, 6.5.x-docs, alice, vulcan, spock, 5.0.1]
+    branches: [master, cheshire-cat, mad-hatter, 6.5.x-docs, alice, vulcan, spock, 5.0.1]
     start_path: docs
   - url: https://git@github.com/couchbase/backup
-    branches: [cheshire-cat, mad-hatter, 6.5.x-docs, alice, vulcan, spock, 5.0.x]
+    branches: [master, cheshire-cat, mad-hatter, 6.5.x-docs, alice, vulcan, spock, 5.0.x]
     start_path: docs
   - url: https://github.com/couchbaselabs/cb-swagger
-    branches: [release/7.0, release/6.6, release/6.5, release/6.0]
+    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0]
     start_path: docs
   # NOTE docs-server is currently after other server repos so nav key wins
   - url: https://github.com/couchbase/docs-server
-    branches: [dev-reorg, release/7.0, release/6.6, release/6.5, release/6.0, release/5.5, release/5.1, release/5.0]
+    branches: [release/7.1, dev-reorg, release/7.0, release/6.6, release/6.5, release/6.0, release/5.5, release/5.1, release/5.0]
   - url: https://github.com/couchbase/docs-sdk-common
-    branches: [release/7.0, release/6.6, release/6.5, release/6.0, release/5.5]
+    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0, release/5.5]
   - url: https://github.com/couchbase/docs-sdk-c
     branches: [release/3.2, release/3.1, release/3.0, release/2.10]
   - url: https://github.com/couchbase/docs-txn-cxx

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -47,21 +47,21 @@ content:
     start_path: docs
   - url: https://git@github.com/couchbase/docs-connectors-talend
   - url: https://git@github.com/couchbase/docs-analytics
-    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0, release/5.5]
+    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0]
   - url: https://github.com/couchbase/couchbase-cli
-    branches: [master, cheshire-cat, mad-hatter, 6.5.x-docs, alice, vulcan, spock, 5.0.1]
+    branches: [master, cheshire-cat, mad-hatter, 6.5.x-docs, alice]
     start_path: docs
   - url: https://git@github.com/couchbase/backup
-    branches: [master, cheshire-cat, mad-hatter, 6.5.x-docs, alice, vulcan, spock, 5.0.x]
+    branches: [master, cheshire-cat, mad-hatter, 6.5.x-docs, alice]
     start_path: docs
   - url: https://github.com/couchbaselabs/cb-swagger
     branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0]
     start_path: docs
   # NOTE docs-server is currently after other server repos so nav key wins
   - url: https://github.com/couchbase/docs-server
-    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0, release/5.5, release/5.1, release/5.0]
+    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0]
   - url: https://github.com/couchbase/docs-sdk-common
-    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0, release/5.5]
+    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0]
   - url: https://github.com/couchbase/docs-sdk-c
     branches: [release/3.2, release/3.1, release/3.0, release/2.10]
   - url: https://github.com/couchbase/docs-txn-cxx

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -47,21 +47,21 @@ content:
     start_path: docs
   - url: https://git@github.com/couchbase/docs-connectors-talend
   - url: https://git@github.com/couchbase/docs-analytics
-    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0]
+    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0, release/5.5]
   - url: https://github.com/couchbase/couchbase-cli
-    branches: [master, cheshire-cat, mad-hatter, 6.5.x-docs, alice]
+    branches: [master, cheshire-cat, mad-hatter, 6.5.x-docs, alice, vulcan, spock, 5.0.1]
     start_path: docs
   - url: https://git@github.com/couchbase/backup
-    branches: [master, cheshire-cat, mad-hatter, 6.5.x-docs, alice]
+    branches: [master, cheshire-cat, mad-hatter, 6.5.x-docs, alice, vulcan, spock, 5.0.x]
     start_path: docs
   - url: https://github.com/couchbaselabs/cb-swagger
     branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0]
     start_path: docs
   # NOTE docs-server is currently after other server repos so nav key wins
   - url: https://github.com/couchbase/docs-server
-    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0]
+    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0, release/5.5, release/5.1, release/5.0]
   - url: https://github.com/couchbase/docs-sdk-common
-    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0]
+    branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0, release/5.5]
   - url: https://github.com/couchbase/docs-sdk-c
     branches: [release/3.2, release/3.1, release/3.0, release/2.10]
   - url: https://github.com/couchbase/docs-txn-cxx


### PR DESCRIPTION
Second attempt. Removing all versions earlier than 6.0 from the staging site to cut down on build times, given that version 5.5 is now unsupported.

UPDATE: removing all versions earlier than 6.0 didn't work, but removing `dev-reorg` did. Seems we can't have `dev-reorg` and `release/7.1` at the same time.