### PR TITLE
Configure default page-toclevels

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -134,6 +134,7 @@ asciidoc:
     idseparator: '-@'
     tabs: tabs
     toc: ~
+    page-toclevels: 1@
     xrefstyle: short
     enterprise: https://www.couchbase.com/products/editions[ENTERPRISE EDITION]
     community: https://www.couchbase.com/products/editions[COMMUNITY EDITION]


### PR DESCRIPTION
Apologies, this should have been part of
https://github.com/couchbase/docs-site/pull/427

However this isn't urgent, as (different to Antora default), we
set the default levels to 1:
  https://github.com/couchbase/docs-ui/pull/126/commits/301699460a541d52157af31923400e4594c6ddf6

This config change simply declares this as a default, which can be overridden
by pages as per:
  https://github.com/couchbase/docs-sdk-java/commit/e3dc20c8462228bdc4e9348e7801c8af5936d2b7