### PR TITLE
Doc 9391 – moving release/5.5, release/5.1 and release/5.0 to archive master branch

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -50,7 +50,7 @@ content:
   - url: https://git@github.com/couchbase/docs-analytics
     branches: [release/7.0, release/6.6, release/6.5, release/6.0, release/5.5]
   - url: https://github.com/couchbase/couchbase-cli
-    branches: [cheshire-cat, mad-hatter, 6.5.x-docs, alice, vulcan, spock, 5.0.1]
+    branches: [cheshire-cat, mad-hatter, 6.5.x-docs, alice]
     start_path: docs
   - url: https://git@github.com/couchbase/backup
     branches: [cheshire-cat, mad-hatter, 6.5.x-docs, alice, vulcan, spock, 5.0.x]

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -60,7 +60,7 @@ content:
     start_path: docs
   # NOTE docs-server is currently after other server repos so nav key wins
   - url: https://github.com/couchbase/docs-server
-    branches: [release/7.0, release/6.6, release/6.5, release/6.0, release/5.5, release/5.1, release/5.0]
+    branches: [release/7.0, release/6.6, release/6.5, release/6.0]
   - url: https://github.com/couchbase/docs-sdk-common
     branches: [release/7.0, release/6.6, release/6.5, release/6.0, release/5.5]
   - url: https://github.com/couchbase/docs-sdk-c


### PR DESCRIPTION
Moved these to the archive site in a separate PR (433)