### PR TITLE
DOC-9421 - Add CMOS project to site [STAGING]

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -133,6 +133,7 @@ content:
     start_path: content
 asciidoc:
   attributes:
+    enable-cmos: ''
     max-include-depth: 10
     page-partial: false
     experimental: ''

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -14,6 +14,7 @@ site:
         { "title": "Cloud", "startPage": "cloud::index.adoc", "components": ["cloud"] },
         { "title": "Cloud-Native", "startPage": "cloud-native-database::index.adoc", "components": ["cloud-native-database"] },
         { "title": "Autonomous Operator", "components": ["operator"] },
+        { "title": "CMOS", "components": ["cmos"] },
         { "title": "Service Broker", "components": ["service-broker"] },
         { "title": "SDKs", "startPage": "home::sdk.adoc", "components": ["*-sdk", "cxx-txns", "elasticsearch-connector", "kafka-connector", "spark-connector"] },
         { "title": "Tutorials", "startPage": "tutorials::index.adoc", "components": ["tutorials"] }
@@ -36,6 +37,9 @@ content:
   - url: https://git@github.com/couchbase/couchbase-operator
     branches: [master, 2.3.0-beta, 2.2.x, 2.1.x, 2.0.x, 1.2.x, 1.1.x, 1.0.x]
     start_path: docs/user
+  - url: https://github.com/couchbaselabs/observability
+    branches: [main]
+    start_path: docs
   - url: https://github.com/couchbase/couchbase-elasticsearch-connector
     branches: [release/4.2, release/4.1, release/4.0]
     start_path: docs

--- a/home/modules/ROOT/pages/cloud.adoc
+++ b/home/modules/ROOT/pages/cloud.adoc
@@ -77,6 +77,15 @@ The Service Broker implements the https://www.openservicebrokerapi.org/[Open Ser
 []
 xref:service-broker::index.adoc[Go to Couchbase Service Broker]
 
+[.column]
+====== {empty}
+.Couchbase Monitoring and Observability Stack
+
+[.content]
+The Couchbase Monitoring and Observability Stack (CMOS) is a simple, out-of-the-box solution based on industry standard tooling to observe the state of your Couchbase cluster.
+[]
+xref:cmos::index.adoc[Go to Couchbase Monitoring and Observability Stack]
+
 ++++
 </div>
 ++++

--- a/home/modules/ROOT/pages/index.adoc
+++ b/home/modules/ROOT/pages/index.adoc
@@ -174,6 +174,8 @@ xref:operator::overview.adoc[Couchbase Autonomous Operator]
 
 xref:service-broker::index.adoc[Couchbase Service Broker]
 
+xref:cmos::index.adoc[Couchbase Monitoring and Observability Stack]
+
 a| xref:java-sdk:hello-world:overview.adoc[Couchbase Java SDK]
 
 xref:scala-sdk:hello-world:overview.adoc[Couchbase Scala SDK]

--- a/home/modules/contribute/pages/repositories.adoc
+++ b/home/modules/contribute/pages/repositories.adoc
@@ -18,6 +18,7 @@
 :url-git-sdk-common: {url-git-cb}/docs-sdk-common
 :url-git-home: {url-git-cb}/docs-site
 :url-git-operator: {url-git-cb}/couchbase-operator
+:url-git-cmos: {url-git-labs}/observability
 :url-git-asterix: {url-git-labs}/asterix-opt
 :url-git-elastic: {url-git-labs}/couchbase-elasticsearch-connector
 :url-git-kafka: {url-git-cb}/kafka-connect-couchbase

--- a/home/modules/contribute/pages/word-list.adoc
+++ b/home/modules/contribute/pages/word-list.adoc
@@ -110,6 +110,8 @@ New Yorker, in particular, presents some interesting alternatives, and we may be
 | `ConfigProviderBase` |
 | Couchbase | is the _company_ name, _Couchbase Server_, or _Couchbase Foo_, the product name
 | Couchbase Autonomous Operator | CAO
+| Couchbase Monitoring and Observability Stack | CMOS 
+| Couchbase Capella | formerly known as "Couchbase Cloud" or "Couchbase Managed Cloud"
 | (the) Couchbase Data Platform | data platform if not preceded by _Couchbase_
 | Couchbase Eventing Service |
 | Couchbase Functions |


### PR DESCRIPTION
Setting up our staging site with CMOS docs, let's see if I break anything 😄 , hopefully it should just work(tested on local and seemed fine).
Also added a change in [cloud-native-database](https://github.com/couchbase/docs-cloud-native/pull/24) to setup the left hand nav title.