### PR TITLE
Unrevert dotnet SDK change, back to 3.2.4

### DIFF
--- a/etc/nginx/snippets/rewrites.conf
+++ b/etc/nginx/snippets/rewrites.conf
@@ -1,7 +1,7 @@
 # NOTE rewrite uses 302 redirect by default (assuming replacement does not start with a protocol)
 # current versions
 set $current_version_sdk_c_api '3.2.3';
-set $current_version_sdk_dotnet_api '3.2.3';
+set $current_version_sdk_dotnet_api '3.2.4';
 set $current_version_sdk_go_api '2.3.4';
 set $current_version_sdk_java_api '3.2.3';
 set $current_version_sdk_jvm_core_api '2.2.3';


### PR DESCRIPTION
Reverting 45c53ec9ba25bd66edbb48459e45dfc88571af7d  
Now that https://issues.couchbase.com/browse/NCBC-3011 is fixed