### PR TITLE
[DOC-9449] - Point to modules page in Node.js API doc

### DIFF
--- a/home/modules/ROOT/pages/sdk.adoc
+++ b/home/modules/ROOT/pages/sdk.adoc
@@ -49,7 +49,7 @@ They offer traditional synchronous APIs as well as scalable asynchronous APIs to
 
 | Node.js SDK
 | xref:3.2@nodejs-sdk:hello-world:overview.adoc[Docs]
-| https://docs.couchbase.com/sdk-api/couchbase-node-client[API Reference]
+| https://docs.couchbase.com/sdk-api/couchbase-node-client/modules.html[API Reference]
 
 | PHP SDK
 | xref:3.2@php-sdk:hello-world:overview.adoc[Docs]


### PR DESCRIPTION
https://issues.couchbase.com/browse/DOC-9449

The new Nodejs 3.2 API doc front page seems quite confusing for users, let's point directly to the modules page where all the objects and functions are listed.