### PR TITLE
Retrieve light icon set for fontawesome

### DIFF
--- a/scripts/package.json
+++ b/scripts/package.json
@@ -12,6 +12,7 @@
   },
   "optionalDependencies": {
     "@fortawesome/pro-solid-svg-icons": "~5.15",
-    "@fortawesome/pro-regular-svg-icons": "~5.15"
+    "@fortawesome/pro-regular-svg-icons": "~5.15",
+    "@fortawesome/pro-light-svg-icons": "~5.15"
   }
 }

--- a/scripts/populate-icon-defs.js
+++ b/scripts/populate-icon-defs.js
@@ -25,6 +25,13 @@ const iconPacks = {
       return require('@fortawesome/free-regular-svg-icons')
     }
   })(),
+  fal: (() => {
+    try {
+      return require('@fortawesome/pro-light-svg-icons')
+    } catch (e) {
+      return require('@fortawesome/free-regular-svg-icons')
+    }
+  })(),
   fab: require('@fortawesome/free-brands-svg-icons'),
 }
 iconPacks.fa = iconPacks.fas

--- a/scripts/populate-icon-defs.js
+++ b/scripts/populate-icon-defs.js
@@ -29,8 +29,8 @@ const iconPacks = {
     try {
       return require('@fortawesome/pro-light-svg-icons')
     } catch (e) {
-      return require('@fortawesome/free-regular-svg-icons')
-    }
+      console.log('FontAwesome Light icons not found.')
+      return null    }
   })(),
   fab: require('@fortawesome/free-brands-svg-icons'),
 }


### PR DESCRIPTION
Made a change to the doc site so that the light elements of Font awesome can be used.