### PR TITLE
Add start_path for userprofile-couchbase-mobile-android

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -128,6 +128,7 @@ content:
   - url: https://github.com/couchbaselabs/couchbase-lite-ios-api-playground
   - url: https://github.com/couchbaselabs/userprofile-couchbase-mobile-android
     branches: [standalone, query, sync]
+    start_path: content
   - url: https://github.com/amarantha-k/OpenID_connect_tutorial
     branches: [tutorial]
     start_path: content


### PR DESCRIPTION
Looks like the structure of the [userprofile-couchbase-mobile-android](https://github.com/couchbaselabs/userprofile-couchbase-mobile-android) repo has changed a bit and the `antora.yml` has moved to the `content` directory.

This has changed in all three branches: `query`, `standalone`, and `sync`. From what I can see `master` is not used.
