### PR TITLE
Fixing location for mobile-android content

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -119,6 +119,7 @@ content:
   - url: https://github.com/couchbaselabs/couchbase-lite-ios-api-playground
   - url: https://github.com/couchbaselabs/userprofile-couchbase-mobile-android
     branches: [standalone, query, sync]
+    start_path: content
   - url: https://github.com/amarantha-k/OpenID_connect_tutorial
     branches: [tutorial]
     start_path: content


### PR DESCRIPTION
The build is a bit smashed because https://github.com/couchbaselabs/userprofile-couchbase-mobile-android has its content located in a subdirectory. 
Fixing the playbook so that it can find it.