### PR TITLE
Show deploy preview errors on failure

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -132,7 +132,7 @@ asciidoc:
     page-partial: false
     experimental: ''
     idprefix: '@'
-    idseparator: 1
+    idseparator: '-@'
     tabs: tabs
     toc: ~
     page-toclevels: 1@


### PR DESCRIPTION
Specifically doing this on failure because the Deploy Previews are done on Netlify and we don't want to fill up the logs with all our warnings every time a build runs.
