### PR TITLE
removing global from kroki install

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,7 +94,7 @@ pipeline {
             script {
               // NOTE to enforce this validation, remove this try-catch block
               try {
-                sh "sudo npm install -g asciidoctor-kroki" 
+                sh "npm install asciidoctor-kroki" 
                 sh "time antora --cache-dir=./.cache/antora --fetch --generator=@antora/xref-validator --stacktrace antora-playbook.yml >xref-validator.log 2>&1"
               } catch (err) {
                 def report = readFile('xref-validator.log')


### PR DESCRIPTION
So, no sudo, so we'll try just removing the global install clause, and see if it can still pick up the module.