### PR TITLE
rayoffiah-remove_kroki_from_staging

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -158,8 +158,6 @@ asciidoc:
     enterprise: https://www.couchbase.com/products/editions[ENTERPRISE EDITION]
     community: https://www.couchbase.com/products/editions[COMMUNITY EDITION]
     sqlpp: SQL++
-    kroki-server-url: http://3.91.133.254:9500
-    kroki-fetch-diagram: true
   extensions:
   - ./lib/source-url-include-processor.js
   - ./lib/json-config-ui-block-macro.js
@@ -167,7 +165,6 @@ asciidoc:
   - ./lib/multirow-table-head-tree-processor.js
   - ./lib/swagger-ui-block-macro.js
   - ./lib/tabs-block.js
-  - asciidoctor-kroki
 ui:
   bundle:
     url: https://github.com/couchbase/docs-ui/releases/download/prod-143/ui-bundle.zip


### PR DESCRIPTION
Netlify choking because it can't access our Kroki servers. Removed the Kroki installation from Staging.