### PR TITLE
[NO ISSUE] Revert attribute for query language

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -154,7 +154,7 @@ asciidoc:
     xrefstyle: short
     enterprise: https://www.couchbase.com/products/editions[ENTERPRISE EDITION]
     community: https://www.couchbase.com/products/editions[COMMUNITY EDITION]
-    sqlpp: SQL++
+    sqlpp: N1QL
     kroki-server-url: http://3.91.133.254:9500
     kroki-fetch-diagram: true
   extensions:


### PR DESCRIPTION
We should not change the name of the query language until (a) we have introduced this attribute consistently across the entire documentation set, as far as possible; and (b) the plan to change the name has actually been finalized.