### PR TITLE
NO ISSUE: Remove references to 7.0

### DIFF
--- a/home/modules/ROOT/pages/server.adoc
+++ b/home/modules/ROOT/pages/server.adoc
@@ -46,10 +46,10 @@ xref:server:getting-started:start-here.adoc[Get Started]
 
 [.column]
 ====== {empty}
-.Upgrading to v7.0
+.Upgrading to v7.x
 
 [.content]
-If you are an existing Couchbase user looking for information to upgrade to Couchbase Server 7.0 and use collections and scopes, see xref:server:install:migrating-application-data.adoc[Upgrade and migrate your data to v7.0].
+If you are an existing Couchbase user looking for information to upgrade to Couchbase Server 7.x and use collections and scopes, see xref:server:install:migrating-application-data.adoc[Upgrade and migrate your data to v7.x].
 
 [.column]
 ====== {empty}
@@ -197,7 +197,7 @@ Explore Couchbase https://developer.couchbase.com/topic/tutorials/[Tutorials] to
 * xref:server:install:install-uninstalling.adoc[Uninstall]
 
 [.column]
-.Migrating to v7.0
+.Migrating to v7.x
 * xref:server:install:migrating-application-data.adoc[Migrating to a collection-based data model]
 * https://blog.couchbase.com/moving-from-sql-server-to-couchbase-part-1-data-modeling/[Migrating to Couchbase]
 

--- a/home/modules/contribute/pages/word-list.adoc
+++ b/home/modules/contribute/pages/word-list.adoc
@@ -49,7 +49,7 @@ New Yorker, in particular, presents some interesting alternatives, and we may be
 | APAC |
 | API |
 | App / Application | _apps_ as restricted & reduced in functionality. Can be used in Mobile component, for example. _Application_ is the preferred term for client software generally. Note, refer to Couchbase (Server & other software) itself as an _application_. For avoiding app/application, use _Client_
-| as of | Use only when referring to dates or time. If talking about a software version, use a phrase such as _beginning with Couchbase Server 7.0_
+| as of | Use only when referring to dates or time. If talking about a software version, use a phrase such as _beginning with Couchbase Server n.n_
 | ASCII | uppercase!
 | autocomplete |  (noun) auto-complete (verb)
 | Auto-failover | noun. Phrasal verb is _automatically fails over_ or _fails over automatically_. Don’t use as one word -- _AutoFailover_ -- except as command name part
@@ -116,7 +116,7 @@ New Yorker, in particular, presents some interesting alternatives, and we may be
 | Couchbase Eventing Service |
 | Couchbase Functions |
 | Couchbase Managed Cloud |
-| Couchbase Server 7.0 | first instance; abbreviate to Server 7.0 in subsequent instances. When referencing general (both) okay to use Couchbase Server alone, no article
+| Couchbase Server n.n | first instance; abbreviate to Server n.n in subsequent instances. When referencing general (both) okay to use Couchbase Server alone, no article
 | Couchstore |
 | cross datacenter replication (XDCR) |
 | cURL | is the name of Daniel Stenberg's data transfer tool (_Client URL_). `curl` is the verb, and its use on the command line


### PR DESCRIPTION
For Neo release.

* The references to `7.0` on the server landing page are all to do with upgrading to use scopes and collections, so I have replaced with `7.x` for more generic relevance. We can revisit this for 8.x 😉 

* Replaced references to `7.0` in the wordlist with a more generic `n.n`