### PR TITLE
DOC-7823 - Fix Server & SDK landing pages

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -171,6 +171,6 @@ asciidoc:
   - asciidoctor-kroki
 ui:
   bundle:
-    url: https://github.com/couchbase/docs-ui/releases/download/prod-146/ui-bundle.zip
+    url: https://github.com/couchbase/docs-ui/releases/download/prod-147/ui-bundle.zip
 output:
   dir: ./public

--- a/home/modules/ROOT/pages/sdk.adoc
+++ b/home/modules/ROOT/pages/sdk.adoc
@@ -22,6 +22,8 @@ collection.reactive.upsert("document-key", json)
     .subscribe()
 ----
 
+====== {empty}
+
 == Server SDKs
 
 The Couchbase SDKs allows applications to access a Couchbase cluster. 
@@ -32,43 +34,43 @@ They offer traditional synchronous APIs as well as scalable asynchronous APIs to
 | SDK | Documentation | API Reference
 
 | Java SDK
-| xref:3.3@java-sdk:hello-world:overview.adoc[Docs]
+| xref:java-sdk:hello-world:overview.adoc[Docs]
 | https://docs.couchbase.com/sdk-api/couchbase-java-client[API Reference]
 
 | Kotlin SDK
-| xref:1.0@kotlin-sdk:hello-world:overview.adoc[Docs]
+| xref:kotlin-sdk:hello-world:overview.adoc[Docs]
 | https://docs.couchbase.com/sdk-api/couchbase-kotlin-client[API Reference]
 
 | Scala SDK
-| xref:1.3@scala-sdk:hello-world:overview.adoc[Docs]
+| xref:scala-sdk:hello-world:overview.adoc[Docs]
 | https://docs.couchbase.com/sdk-api/couchbase-scala-client/com/couchbase/client/scala/index.html[API Reference]
 
 | .NET SDK
-| xref:3.3@dotnet-sdk:hello-world:overview.adoc[Docs]
+| xref:dotnet-sdk:hello-world:overview.adoc[Docs]
 | https://docs.couchbase.com/sdk-api/couchbase-net-client[API Reference]
 
 | C SDK
-| xref:3.3@c-sdk:hello-world:overview.adoc[Docs]
+| xref:c-sdk:hello-world:overview.adoc[Docs]
 | https://docs.couchbase.com/sdk-api/couchbase-c-client/index.html[API Reference]
 
 | Node.js SDK
-| xref:4.1@nodejs-sdk:hello-world:overview.adoc[Docs]
+| xref:nodejs-sdk:hello-world:overview.adoc[Docs]
 | https://docs.couchbase.com/sdk-api/couchbase-node-client/modules.html[API Reference]
 
 | PHP SDK
-| xref:4.0@php-sdk:hello-world:overview.adoc[Docs]
+| xref:php-sdk:hello-world:overview.adoc[Docs]
 | https://docs.couchbase.com/sdk-api/couchbase-php-client/namespaces/couchbase.html[API Reference]
 
 | Python SDK
-| xref:4.0@python-sdk:hello-world:overview.adoc[Docs]
+| xref:python-sdk:hello-world:overview.adoc[Docs]
 | https://docs.couchbase.com/sdk-api/couchbase-python-client/[API Reference]
 
 | Ruby SDK
-| xref:3.3@ruby-sdk:hello-world:overview.adoc[Docs]
+| xref:ruby-sdk:hello-world:overview.adoc[Docs]
 | https://docs.couchbase.com/sdk-api/couchbase-ruby-client/Couchbase.html[API Reference]
 
 | Go SDK
-| xref:2.5@go-sdk:hello-world:overview.adoc[Docs]
+| xref:go-sdk:hello-world:overview.adoc[Docs]
 | https://pkg.go.dev/github.com/couchbase/gocb/v2[API Reference]
 |===
 

--- a/home/modules/ROOT/pages/server.adoc
+++ b/home/modules/ROOT/pages/server.adoc
@@ -29,6 +29,8 @@ try {
 }
 ----
 
+====== {empty}
+
 == Get Started
 
 ++++


### PR DESCRIPTION
Fixes missing bullet points in SDK landing pages and weird extra padding.
Needs https://github.com/couchbase/docs-ui/pull/138 to be merged first.

I've generated the docs site locally and published to Github pages so you can see a preview (includes my ui changes):
- [**SDKs Landing Page**](https://maria-robobug.github.io/fix-landing-pages/home/sdk.html)
- [**Single SDK Landing Page (Java, but see others too)**](https://maria-robobug.github.io/fix-landing-pages/java-sdk/3.3/hello-world/overview.html) 
- [**Server Landing Page**](https://maria-robobug.github.io/fix-landing-pages/home/server.html)

Also changed the sdk xrefs to point to the latest page -- let's avoid maintenance headaches 😆 .

Please let me know if anything looks weird. 
I'm going to test on staging first and then eventually go to prod -- so far it seems to work though from what I've tested locally 🤞 .