### PR TITLE
Point OpenID tutorial to couchbaselabs

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -136,6 +136,9 @@ content:
   - url: https://github.com/couchbaselabs/userprofile-couchbase-mobile-android
     branches: [standalone, query, sync]
     start_path: content
+  - url: htts://github.com/couchbaselabs/OpenID_connect_tutorial
+      branches: [tutorial]
+      start_path: content
   # - url: https://github.com/amarantha-k/OpenID_connect_tutorial
   #   branches: [tutorial]
   #   start_path: content


### PR DESCRIPTION
Change pull for the OpenID auth tutorial to point to couchbase labs instead of Amarantha's personal github.