### PR TITLE
Java, Scala, and Python releases

### DIFF
--- a/etc/nginx/snippets/rewrites.conf
+++ b/etc/nginx/snippets/rewrites.conf
@@ -3,14 +3,14 @@
 set $current_version_sdk_c_api '3.3.0';
 set $current_version_sdk_dotnet_api '3.3.1';
 set $current_version_sdk_go_api '2.5.0';
-set $current_version_sdk_java_api '3.3.1';
+set $current_version_sdk_java_api '3.3.2';
 set $current_version_sdk_jvm_core_api '2.3.1';
 set $current_version_kotlin_client_api '1.0.1';
 set $current_version_sdk_nodejs_api '4.1.1';
 set $current_version_sdk_php_api '4.0.0';
-set $current_version_sdk_python_api '4.0.1';
+set $current_version_sdk_python_api '4.0.2';
 set $current_version_sdk_ruby_api '3.3.0';
-set $current_version_sdk_scala_api '1.3.1';
+set $current_version_sdk_scala_api '1.3.2';
 set $current_version_txns_java_api '1.2.4';
 set $current_version_txns_cxx_api '1.0.0';
 set $current_version_txns_dotnet_api '1.1.0';


### PR DESCRIPTION
- Java 3.3.2
- Scala 1.3.2
- Python 4.0.2