### PR TITLE
Revert "AV-39681 stage July 2022 changes for capella (#586)"

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -36,8 +36,7 @@ content:
     branches: HEAD
     start_path: home
   - url: https://git@github.com/couchbasecloud/couchbase-cloud
-    # branches: [main]
-    branches: [AV-39681-Ongoing-work-gcp-ga-docs]
+    branches: [main]
     start_path: docs/public
   - url: https://git@github.com/couchbase/couchbase-operator
     branches: [master, 2.3.x, 2.2.x, 2.1.x, 2.0.x, 1.2.x, 1.1.x, 1.0.x]


### PR DESCRIPTION
This reverts commit 015e226a2ac239ab22018ab37dfd5751db48bbd9.

(To test on staging that Capella release is correct against main) 