### PR TITLE
Build Elasticsearch connector 4.4 docs from master branch

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -49,7 +49,7 @@ content:
     branches: [0.2.x]
     start_path: docs
   - url: https://github.com/couchbase/couchbase-elasticsearch-connector
-    branches: [release/4.3, release/4.2, release/4.1, release/4.0]
+    branches: [master, release/4.3, release/4.2, release/4.1, release/4.0]
     start_path: docs
   - url: https://github.com/couchbase/kafka-connect-couchbase
     branches: [master, release/4.0, release/3.4]


### PR DESCRIPTION
Don't merge this yet, waiting for this to go in for Monday 1st August 2022.