### PR TITLE
update-staging-to-ui-157

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -179,7 +179,7 @@ asciidoc:
   - asciidoctor-external-callout
 ui:
   bundle:
-    url: https://github.com/couchbase/docs-ui/releases/download/prod-156/ui-bundle.zip
+    url: https://github.com/couchbase/docs-ui/releases/download/prod-157/ui-bundle.zip
     #url: https://deploy-preview-xxx--cb-docs-ui.netlify.app/dist/ui-bundle.zip
     #snapshot: true
 output:


### PR DESCRIPTION
This adds brings back the SQL++ language to the syntax highlighter, using sqlpp as the language name.