### PR TITLE
Add docs-devex repo to playbook

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -36,6 +36,8 @@ content:
   - url: .
     branches: HEAD
     start_path: home
+  - url: https://github.com/couchbaselabs/docs-devex
+    branches: [search-server,search-capella]
   - url: https://git@github.com/couchbasecloud/couchbase-cloud
     branches: [main]
     start_path: docs/public


### PR DESCRIPTION
Part of striping and branching investigation:

* Playbook: this PR
* Devex Capella branch: [couchbaselabs/docs-devex#1](https://github.com/couchbaselabs/docs-devex/pull/1)
* Devex Server branch: [couchbaselabs/docs-devex#2](https://github.com/couchbaselabs/docs-devex/pull/2)
* Server nav: [couchbase/docs-server#3032](https://github.com/couchbase/docs-server/pull/3032)

There would be a similar inclusion in the Couchbase Cloud nav &mdash; there is no PR for that change.