### PR TITLE
DOC-10775: Docs infrastructure for 7.2.0

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -64,10 +64,10 @@ content:
   - url: https://git@github.com/couchbase/docs-analytics
     branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0]
   - url: https://github.com/couchbase/couchbase-cli
-    branches: [neo, cheshire-cat, mad-hatter, 6.5.x-docs, alice]
+    branches: [7.1.x-docs, cheshire-cat, mad-hatter, 6.5.x-docs, alice]
     start_path: docs
   - url: https://git@github.com/couchbase/backup
-    branches: [neo, cheshire-cat, mad-hatter, 6.5.x-docs, alice]
+    branches: [7.1.x-docs, cheshire-cat, mad-hatter, 6.5.x-docs, alice]
     start_path: docs
   - url: https://github.com/couchbaselabs/cb-swagger
     branches: [release/7.1, release/7.0, release/6.6, release/6.5, release/6.0]


### PR DESCRIPTION
Follow-up change to #653 — use the `7.1.x-docs` branch for the backup and couchbase-cli docs for release 7.1.

Docs issue: [DOC-10775](https://issues.couchbase.com/browse/DOC-10775)