### PR TITLE
DOC-10800: Migrate how-to guides to docs-devex

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -35,6 +35,8 @@ content:
   - url: .
     branches: HEAD
     start_path: home
+  - url: https://github.com/couchbaselabs/docs-devex
+    branches: [release/7.2, capella]
   - url: https://git@github.com/couchbasecloud/couchbase-cloud
     branches: [main]
 #    branches: [TEMP-DOCS-nux-changes]

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -36,7 +36,8 @@ content:
     branches: HEAD
     start_path: home
   - url: https://github.com/couchbaselabs/docs-devex
-    branches: [release/7.2, capella]
+    branches: [release/7.2]
+    # branches: [release/7.2, capella]
   - url: https://git@github.com/couchbasecloud/couchbase-cloud
     branches: [main]
 #    branches: [TEMP-DOCS-nux-changes]


### PR DESCRIPTION
Adds the docs-devex repo to the `staging` playbook, before cloud and server. See also:

* [couchbase/docs-server#3069](https://github.com/couchbase/docs-server/pull/3069)
* [couchbaselabs/docs-devex#5](https://github.com/couchbaselabs/docs-devex/pull/5)

Docs issue: [DOC-10800](https://issues.couchbase.com/browse/DOC-10800)