### PR TITLE
AV-50499: Embargo Pages (STAGING)

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -4,6 +4,8 @@
 antora:
   extensions:
   - '@antora/site-generator-ms'
+  - ./lib/embargo.js
+
 site:
   title: Couchbase Docs Staging
   url: https://docs-staging.couchbase.com

--- a/home/modules/contribute/pages/extensions-embargoed.adoc
+++ b/home/modules/contribute/pages/extensions-embargoed.adoc
@@ -1,0 +1,5 @@
+:page-embargo: EMBARGOED
+= This page is embargoed!
+
+This page should not be output.
+See `lib/embargo.js` and AV-50499

--- a/home/modules/contribute/pages/extensions-flagged.adoc
+++ b/home/modules/contribute/pages/extensions-flagged.adoc
@@ -1,0 +1,41 @@
+= Demo about the Feature Flag
+
+See https://github.com/couchbaselabs/docs-tooling/tree/main/flags for installation and more details.
+
+ifdef::flag-kitten[]
+NOTE: `DEBUG: flag-kitten`
+endif::flag-kitten[]
+
+ifdef::flag-cloud[]
+NOTE: `DEBUG: flag-cloud`
+endif::flag-cloud[]
+
+== How Couchbase Works
+
+Couchbase works very well.
+
+ifdef::flag-cloud[]
+Couchbase now LIVES IN THE CLOUD!
+endif::flag-cloud[]
+
+ifdef::flag-kitten[]
+Couchbase is powered by KITTENS!
+endif::flag-kitten[]
+
+ifdef::flag-cloud[]
+ifdef::flag-kitten[]
+The KITTENS are playing in the CLOUD!
+endif::flag-kitten[]
+endif::flag-cloud[]
+
+== Limitations
+
+* Blah blah
+
+ifndef::flag-kitten[]
+* Couchbase does not have a fluffy tummy.
+endif::flag-kitten[]
+
+ifndef::flag-cloud[]
+* Couchbase is not provisioned on demand in the cloud.
+endif::flag-cloud[]

--- a/lib/embargo.js
+++ b/lib/embargo.js
@@ -1,0 +1,26 @@
+module.exports.register = function ({ config }) {
+  const logger = this.getLogger('embargo-extension')
+  this
+    .on('navigationBuilt', ({ contentCatalog }) => {
+      contentCatalog.getComponents().forEach(({ versions }) => {
+        versions.forEach(({ name: component, version, navigation: nav, url: defaultUrl }) => {
+          contentCatalog
+            .findBy({ component, version, family: 'page' })
+            .filter((page) => page.out)
+            .forEach((page) => {
+              if (page.asciidoc.attributes['page-embargo'] != null) {
+                console.log("Embargoed", page.pub.url, page.asciidoc.attributes['page-embargo'])
+                delete page.pub
+                delete page.out
+                // contentCatalog.removeFile(page)
+              }
+
+            })
+        })
+      })
+    })
+}
+
+
+
+


### PR DESCRIPTION
See https://github.com/couchbase/docs-site/pull/643 for Live PR.

Note that instead of deleting `page.pub` and `page.out`, we could use `contentCatalog.removeFile(page)` but this requires:

* antora 3.1.1 or some release after https://gitlab.com/antora/antora/-/commit/36ae21fae5654b4f9443e6a5cc0a48006c9ec4d7

* We are testing upgrading to 3.1.1 https://support.opendevise.com/support/tickets/170 had some issues in staging. Had to comment out source-url-include-processor.js to run this locally