### PR TITLE
Update capella layout

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -40,7 +40,7 @@ content:
     start_path: home
   - url: https://git@github.com/couchbasecloud/couchbase-cloud
     branches: [main]
-    start_path: docs/public
+    start_path: docs/public/provisioned
   - url: https://git@github.com/couchbase/couchbase-operator
     branches: [2.4.x, 2.3.x, 2.2.x, 2.1.x, 2.0.x, 1.2.x, 1.1.x, 1.0.x]
     start_path: docs/user


### PR DESCRIPTION
This change points the prod playbook to the new layout introduced by https://github.com/couchbasecloud/couchbase-cloud/pull/18906

As we only have a single `start_path`, the user-visible site will be identical to before, as can be tested on docs-staging.