### PR TITLE
Tutorials link

### DIFF
--- a/home/modules/ROOT/pages/index.adoc
+++ b/home/modules/ROOT/pages/index.adoc
@@ -140,6 +140,7 @@ https://couchbase.sh[Explore Couchbase Shell]
 Explore a variety of resources - sample apps, videos, blogs, and more, to build applications using Couchbase.
 
 https://developer.couchbase.com[Developer Portal]
+https://developer.couchbase.com/tutorials[Developer Tutorials]
 
 
 [.column]


### PR DESCRIPTION
Adding tutorials link to DA site,
as the topnav tutorial link has been removed.