### PR TITLE
Fixing docs-search 

### DIFF
--- a/docsearch/Jenkinsfile
+++ b/docsearch/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
     }
     stage('Generate Config') {
       steps {
-        sh '(curl -sL https://docs.couchbase.com/site-manifest.json | npx -p hbs-cli hbs -H "$PWD/docsearch/hbs-helpers/*.js" -i -s $CONFIG.hbs > $CONFIG)'
+        sh '(curl -sL https://docs.couchbase.com/site-manifest.json | npx -p hbs-cli -p glob@8 hbs -H "$PWD/docsearch/hbs-helpers/*.js" -i -s $CONFIG.hbs > $CONFIG)'
       }
     }
     stage('Run') {

--- a/docsearch/hbs-helpers/versioned.js
+++ b/docsearch/hbs-helpers/versioned.js
@@ -1,3 +1,11 @@
-const versioned = (components) => components.filter(({ latest }) => (latest || 'master') != 'master')
+// A component with an empty version (defined as `~` in the playbook.yml) 
+// or named 'master' is considered to be "versionless", so the URL generated
+// will be simply e.g. https://docs.couchbase.com/cloud/
+// whereas a "versioned" component might have /current/ or /7.1/ appended.
+
+const versioned = (components) => components.filter(
+    ({ latest }) =>
+        latest != 'master'
+        && latest != '')
 
 module.exports.register = (hbs) => hbs.registerHelper('versioned', versioned)

--- a/docsearch/hbs-helpers/versioned.js
+++ b/docsearch/hbs-helpers/versioned.js
@@ -1,3 +1,3 @@
-const versioned = (components) => components.filter(({ latest }) => latest !== 'master')
+const versioned = (components) => components.filter(({ latest }) => (latest || 'master') != 'master')
 
 module.exports.register = (hbs) => hbs.registerHelper('versioned', versioned)

--- a/docsearch/hbs-helpers/versionless.js
+++ b/docsearch/hbs-helpers/versionless.js
@@ -1,3 +1,3 @@
-const versionless = (components) => components.filter(({ name, latest }) => name !== 'home' && name !== 'tutorials' && latest === 'master')
+const versionless = (components) => components.filter(({ name, latest }) => name !== 'home' && name !== 'tutorials' && (latest || 'master') === 'master')
 
 module.exports.register = (hbs) => hbs.registerHelper('versionless', versionless)

--- a/docsearch/hbs-helpers/versionless.js
+++ b/docsearch/hbs-helpers/versionless.js
@@ -1,3 +1,17 @@
-const versionless = (components) => components.filter(({ name, latest }) => name !== 'home' && name !== 'tutorials' && (latest || 'master') === 'master')
+// A component with an empty version (defined as `~` in the playbook.yml) 
+// or named 'master' is considered to be "versionless", so the URL generated
+// will be simply e.g. https://docs.couchbase.com/cloud/
+// whereas a "versioned" component might have /current/ or /7.1/ appended.
+//
+// Note that 'home' and 'tutorials' are special-cased elsewhere in the template,
+// and therefore excluded from this filter.
+
+const versionless = (components) => components.filter(
+    ({ name, latest }) =>
+        name !== 'home' 
+        && name !== 'tutorials'
+        && (
+            latest === 'master'
+            || latest === ''))
 
 module.exports.register = (hbs) => hbs.registerHelper('versionless', versionless)


### PR DESCRIPTION
1. use pinned working version of glob
2. edit `versioned` and `versionless` helpers to generate working config for Capella (this was broken by the Hosted/Provisioned config)