### PR TITLE
Info Banner - Capella Spring Release

### DIFF
--- a/home/modules/ROOT/pages/cloud.adoc
+++ b/home/modules/ROOT/pages/cloud.adoc
@@ -3,6 +3,8 @@
 :page-role: tiles
 :!sectids:
 
+include::partial$info-banner.adoc[]
+
 = Couchbase on Containers, Kubernetes, and Cloud
 
 Couchbase Server is designed to run in the most popular cloud and container environments. Deploy Couchbase in the cloud for its unique data model flexibility, elastic scalability, high performance, and 24x365 availability. 

--- a/home/modules/ROOT/pages/index.adoc
+++ b/home/modules/ROOT/pages/index.adoc
@@ -5,6 +5,8 @@
 :!sectids:
 :collapsible:
 
+include::partial$info-banner.adoc[]
+
 = Couchbase Documentation
 
 ++++

--- a/home/modules/ROOT/pages/integrations.adoc
+++ b/home/modules/ROOT/pages/integrations.adoc
@@ -3,6 +3,8 @@
 :page-role: tiles
 :!sectids:
 
+include::partial$info-banner.adoc[]
+
 = Couchbase Connectors
 ++++
 <div class="card-row">

--- a/home/modules/ROOT/pages/mobile.adoc
+++ b/home/modules/ROOT/pages/mobile.adoc
@@ -3,7 +3,10 @@
 :page-role: tiles
 :!sectids:
 
+include::partial$info-banner.adoc[]
+
 = Couchbase Mobile
+
 ++++
 <div class="card-row">
 ++++

--- a/home/modules/ROOT/pages/sdk.adoc
+++ b/home/modules/ROOT/pages/sdk.adoc
@@ -4,6 +4,7 @@
 :page-role: tiles
 :!sectids:
 
+include::partial$info-banner.adoc[]
 
 = SDKs & Connectors
 

--- a/home/modules/ROOT/pages/server.adoc
+++ b/home/modules/ROOT/pages/server.adoc
@@ -4,6 +4,8 @@
 :!sectids:
 :tabs:
 
+include::partial$info-banner.adoc[]
+
 = Couchbase Server
 
 == {empty}

--- a/home/modules/ROOT/partials/info-banner.adoc
+++ b/home/modules/ROOT/partials/info-banner.adoc
@@ -1,0 +1,48 @@
+// This banner partial can be edited to link
+// to marketing or new Docs content as appropriate.
+//
+// This is linked from each of the Landing pages.
+// To *disable* it, simply comment out the text BELOW.
+//
+// See
+// https://couchbasecloud.atlassian.net/browse/AV-56547
+// for the original requirement.
+
+// NOTE: the following CSS will be moved to docs-ui once 
+// iterated and agreed.
+++++
+<style>
+.info-banner {
+    display: block;
+    border: 1px solid #e5e5e5;
+    border-radius: 3px;
+    -webkit-box-shadow: 0 3px 10px rgba(0,0,0,.06);
+    box-shadow: 0 3px 10px rgba(0,0,0,.06);
+    background-image: linear-gradient(to right, #00ace0, #636cdc);
+    padding: 0.75em;
+    margin-top: 0;
+    margin-bottom: 1em;
+
+}
+.doc.landing-page-doc .info-banner p {
+    text-align: center;
+    color: white;
+    font-weight: lighter;
+}
+.info-banner a {
+    color: white;
+    font-size: 18px;
+    font-weight: bold;
+    display: inline-block;
+    border: solid 1px white;
+    padding: 0.5em 1em;
+}
+</style>
+++++
+
+// NOTE: comment the paragraph below to hide the banner.
+[.info-banner]
+The Capella Spring release is here!
+Introducing developer integrations Netlify and VSCode plus more.
+https://www.couchbase.com/blog/couchbase-capella-spring-release-72[Check it out]
+


### PR DESCRIPTION
This is currently on docs-staging.

Note that Cloud and Cloud Native don't show it, because their landing pages are defined in separate projects.
Will generate a PR for them once approved.