### PR TITLE
Minimal reproduction of Antora logging error

### DIFF
--- a/lib/minimal.js
+++ b/lib/minimal.js
@@ -1,0 +1,20 @@
+'use strict'
+
+module.exports.register = function ({ playbook, config }) {
+    const logger = this.getLogger('andora')
+    
+    this.on('contextStarted', ({ playbook }) => {
+        logger.fatal('Context Started (antora logger)')
+        console.log('Context Started (console.log)')
+    })
+    
+    this.on('sitePublished', ({ playbook, siteAsciiDocConfig, siteCatalog, uiCatalog, contentCatalog, publications }) => {
+        logger.fatal('Site Published (antora logger)')
+        console.log('Site Published (console.log)')
+    })
+    
+}
+
+
+
+

--- a/minimal.yml
+++ b/minimal.yml
@@ -1,0 +1,50 @@
+antora:
+  extensions:
+  - '@antora/site-generator-ms'
+site:
+  title: Couchbase Capella Staging Docs
+  url: https://docs.stage.nonprod-project-avengers.com
+  start_page: cloud:ROOT:index.adoc
+  keys:
+    google_analytics: GTM-MVPNN2
+git:
+  ensure_git_suffix: false
+content:
+  branches: master
+  sources:
+  - url: .
+    branches: HEAD
+    start_path: home
+  - url: ../docs-sync-gateway
+    branches: [HEAD]
+asciidoc:
+  attributes:
+    max-include-depth: 10
+    page-partial: false
+    experimental: ''
+    idprefix: '@'
+    idseparator: '-@'
+    tabs: tabs
+    toc: ~
+    sqlpp: SQL++
+    xrefstyle: short
+    enterprise: https://www.couchbase.com/products/editions[ENTERPRISE EDITION]
+    community: https://www.couchbase.com/products/editions[COMMUNITY EDITION]
+    site-navigation-data-path: _/js/site-navigation-data.js
+    kroki-server-url: ~
+    kroki-fetch-diagram: true
+  extensions:
+  - ./lib/source-url-include-processor.js
+  - ./lib/json-config-ui-block-macro.js
+  - ./lib/inline-man-macro.js
+  - ./lib/multirow-table-head-tree-processor.js
+  - ./lib/swagger-ui-block-macro.js
+  - ./lib/tabs-block.js
+  - ./lib/markdown-block.js
+  - ./lib/template-block.js
+  - asciidoctor-kroki
+ui:
+  bundle:
+    url: https://github.com/couchbase/docs-ui-sandbox/releases/download/prod-166/ui-bundle.zip
+output:
+  dir: ./public


### PR DESCRIPTION
FYI @mojavelinux @leeming, the logging error I mentioned, a minimal reproduction.

It looks like if too many errors are sent to the Antora logger, it doesn't finish logging all of them.

Not sure if this is because messages aren't drained before Antora shuts down, or that the logger is otherwise unresponsive.

Case 1: --log-level=fatal
All the messages are seen:

    ❯ antora minimal.yml --extension=lib/minimal.js --log-level=fatal
    [08:34:26.425] FATAL (andora): Context Started (antora logger)
    Context Started (console.log)
    ...
    Site generation complete!
    Open file:///Users/hakimcassimally/couchbase/docs-site/public in a browser to view your site.
    [08:35:10.242] FATAL (andora): Site Published (antora logger)
    Site Published (console.log)

Case 2: --log-level=info
The on('sitePublished') hook is still run (as we see the console.log) however we DO NOT see the FATAL message via the Antora logger.

    ❯ antora minimal.yml --extension=lib/minimal.js --log-level=info
    [08:36:21.272] FATAL (andora): Context Started (antora logger)
    Context Started (console.log)
    ... (a million errors)
    Site generation complete!
    Open file:///Users/hakimcassimally/couchbase/docs-site/public in a browser to view your site.
    Site Published (console.log)