### PR TITLE
AV-57335 POC for analytics include using collector

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -5,6 +5,7 @@ antora:
   extensions:
   - '@antora/site-generator-ms'
   - ./lib/embargo.js
+  - '@antora/collector-extension'
 
 site:
   title: Couchbase Docs

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -73,9 +73,14 @@ content:
     start_path: docs
   # - url: https://git@github.com/couchbase/docs-connectors-talend
   - url: https://github.com/couchbase/docs-connectors-talend
+
   # - url: https://git@github.com/couchbase/docs-analytics
   - url: https://github.com/couchbase/docs-analytics
     branches: [release/7.2, release/7.1, release/7.0, release/6.6, release/6.5, release/6.0]
+  - url: https://github.com/couchbase/asterixdb
+    branches: [master]
+    start_path: asterixdb/asterix-doc/
+
   - url: https://github.com/couchbase/couchbase-cli
     branches: [neo, 7.1.x-docs, cheshire-cat, mad-hatter, 6.5.x-docs, alice]
     start_path: docs

--- a/home/modules/contribute/pages/extensions-collector-analytics.adoc
+++ b/home/modules/contribute/pages/extensions-collector-analytics.adoc
@@ -7,5 +7,5 @@ content in a place that Antora understands it.
 
 [markdown]
 --
-include::analytics:asterixdb:partial$sqlpp/arrayindex.md[]
+include::analytics:asterixdb:partial$builtins/14_window.md[]
 --

--- a/home/modules/contribute/pages/extensions-collector-analytics.adoc
+++ b/home/modules/contribute/pages/extensions-collector-analytics.adoc
@@ -1,0 +1,11 @@
+= Collector extension
+
+See https://gitlab.com/antora/antora-collector-extension
+
+Here's an include from the AsterixDB project which uses collector to put the
+content in a place that Antora understands it.
+
+[markdown]
+--
+include::analytics:asterixdb:partial$sqlpp/arrayindex.md[]
+--

--- a/lib/markdown-block.js
+++ b/lib/markdown-block.js
@@ -1,4 +1,4 @@
-const md = require('markdown-it')()
+const md = require('markdown-it')({ html: true })  
   
 module.exports = function (registry) {
   registry.block(function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "docs-site",
       "dependencies": {
+        "@antora/collector-extension": "^1.0.0-alpha.3",
         "@antora/site-generator-ms": "git+https://gitlab.com/opendevise/oss/antora-site-generator-ms#as-extension",
         "antora": "~3.1",
         "asciidoctor-external-callout": "~1.2.0",
@@ -167,6 +168,21 @@
       "integrity": "sha512-kaDqm1DET9pp3NXwR8382WHbnpXnRkN9xGN9dQt3B2+dmXiW8X1SOwmFOxAErEQ47ObhZ96J6yhZNXuyCOL7KA==",
       "dependencies": {
         "real-require": "^0.2.0"
+      }
+    },
+    "node_modules/@antora/collector-extension": {
+      "version": "1.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@antora/collector-extension/-/collector-extension-1.0.0-alpha.3.tgz",
+      "integrity": "sha512-0yUc+lMVKzXUfOyelGjVO4C2h8ltzYupyWsjymfBPH251Noj9pSlAuzbldjlp7h92dJakgsz+NsLTHIj6lArbQ==",
+      "dependencies": {
+        "@antora/expand-path-helper": "~2.0",
+        "cache-directory": "~2.0",
+        "glob-stream": "~7.0",
+        "isomorphic-git": "~1.21",
+        "js-yaml": "~4.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@antora/expand-path-helper": {
@@ -515,39 +531,10 @@
         "node": ">=14"
       }
     },
-    "node_modules/antora/node_modules/isomorphic-git": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.21.0.tgz",
-      "integrity": "sha512-ZqCAUM63CYepA3fB8H7NVyPSiOkgzIbQ7T+QPrm9xtYgQypN9JUJ5uLMjB5iTfomdJf3mdm6aSxjZwnT6ubvEA==",
-      "dependencies": {
-        "async-lock": "^1.1.0",
-        "clean-git-ref": "^2.0.1",
-        "crc-32": "^1.2.0",
-        "diff3": "0.0.3",
-        "ignore": "^5.1.4",
-        "minimisted": "^2.0.0",
-        "pako": "^1.0.10",
-        "pify": "^4.0.1",
-        "readable-stream": "^3.4.0",
-        "sha.js": "^2.4.9",
-        "simple-get": "^4.0.1"
-      },
-      "bin": {
-        "isogit": "cli.cjs"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/antora/node_modules/on-exit-leak-free": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
       "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w=="
-    },
-    "node_modules/antora/node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/antora/node_modules/pino": {
       "version": "8.7.0",
@@ -3045,6 +3032,35 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/isomorphic-git": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.21.0.tgz",
+      "integrity": "sha512-ZqCAUM63CYepA3fB8H7NVyPSiOkgzIbQ7T+QPrm9xtYgQypN9JUJ5uLMjB5iTfomdJf3mdm6aSxjZwnT6ubvEA==",
+      "dependencies": {
+        "async-lock": "^1.1.0",
+        "clean-git-ref": "^2.0.1",
+        "crc-32": "^1.2.0",
+        "diff3": "0.0.3",
+        "ignore": "^5.1.4",
+        "minimisted": "^2.0.0",
+        "pako": "^1.0.10",
+        "pify": "^4.0.1",
+        "readable-stream": "^3.4.0",
+        "sha.js": "^2.4.9",
+        "simple-get": "^4.0.1"
+      },
+      "bin": {
+        "isogit": "cli.cjs"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/isomorphic-git/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/joycon": {
       "version": "3.1.1",
@@ -6005,6 +6021,18 @@
         }
       }
     },
+    "@antora/collector-extension": {
+      "version": "1.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@antora/collector-extension/-/collector-extension-1.0.0-alpha.3.tgz",
+      "integrity": "sha512-0yUc+lMVKzXUfOyelGjVO4C2h8ltzYupyWsjymfBPH251Noj9pSlAuzbldjlp7h92dJakgsz+NsLTHIj6lArbQ==",
+      "requires": {
+        "@antora/expand-path-helper": "~2.0",
+        "cache-directory": "~2.0",
+        "glob-stream": "~7.0",
+        "isomorphic-git": "~1.21",
+        "js-yaml": "~4.1"
+      }
+    },
     "@antora/expand-path-helper": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@antora/expand-path-helper/-/expand-path-helper-2.0.0.tgz",
@@ -6267,33 +6295,10 @@
           "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.1.0.tgz",
           "integrity": "sha512-bgJcBmNTZaJO03xtXOTNfoFEf/3VwoZ/gJ2O4ekTCZu4LSFtfzQFrJ0kjq8ZSS0+IdghXqQIiDUnpp0eUR9IJg=="
         },
-        "isomorphic-git": {
-          "version": "1.21.0",
-          "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.21.0.tgz",
-          "integrity": "sha512-ZqCAUM63CYepA3fB8H7NVyPSiOkgzIbQ7T+QPrm9xtYgQypN9JUJ5uLMjB5iTfomdJf3mdm6aSxjZwnT6ubvEA==",
-          "requires": {
-            "async-lock": "^1.1.0",
-            "clean-git-ref": "^2.0.1",
-            "crc-32": "^1.2.0",
-            "diff3": "0.0.3",
-            "ignore": "^5.1.4",
-            "minimisted": "^2.0.0",
-            "pako": "^1.0.10",
-            "pify": "^4.0.1",
-            "readable-stream": "^3.4.0",
-            "sha.js": "^2.4.9",
-            "simple-get": "^4.0.1"
-          }
-        },
         "on-exit-leak-free": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
           "integrity": "sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w=="
-        },
-        "pako": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-          "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
         },
         "pino": {
           "version": "8.7.0",
@@ -8290,6 +8295,31 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "isomorphic-git": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.21.0.tgz",
+      "integrity": "sha512-ZqCAUM63CYepA3fB8H7NVyPSiOkgzIbQ7T+QPrm9xtYgQypN9JUJ5uLMjB5iTfomdJf3mdm6aSxjZwnT6ubvEA==",
+      "requires": {
+        "async-lock": "^1.1.0",
+        "clean-git-ref": "^2.0.1",
+        "crc-32": "^1.2.0",
+        "diff3": "0.0.3",
+        "ignore": "^5.1.4",
+        "minimisted": "^2.0.0",
+        "pako": "^1.0.10",
+        "pify": "^4.0.1",
+        "readable-stream": "^3.4.0",
+        "sha.js": "^2.4.9",
+        "simple-get": "^4.0.1"
+      },
+      "dependencies": {
+        "pako": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+          "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+        }
+      }
     },
     "joycon": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "homepage": "https://docs.couchbase.com",
   "private": true,
   "dependencies": {
-    "antora": "~3.1",
+    "@antora/collector-extension": "^1.0.0-alpha.3",
     "@antora/site-generator-ms": "git+https://gitlab.com/opendevise/oss/antora-site-generator-ms#as-extension",
+    "antora": "~3.1",
     "asciidoctor-external-callout": "~1.2.0",
     "asciidoctor-kroki": "0.15.4",
     "gulp": "~4.0",


### PR DESCRIPTION
To simplify process for Analytics team, we can use https://gitlab.com/antora/antora-collector-extension/

NOTE: this extension is currently Alpha, will have to discuss with OpenDevise.

This PR will add the Couchbase fork of AsterixDB and the Collector extension.
A subsequent PR on the AsterixDB repo will provide a command to aggregate sources.
https://github.com/couchbase/asterixdb/pull/2

The .adoc file in this PR includes one of these files, using the Markdown block (modified to cope with the use of HTML in AsterixDB sources)