### PR TITLE
DOC-11173: Docs infrastructure for 7.6.0

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -77,10 +77,12 @@ content:
     branches: [release/7.6, release/7.2, release/7.1, release/7.0, release/6.6]
   - url: https://github.com/couchbase/couchbase-cli
     branches: [neo, 7.1.x-docs, cheshire-cat, mad-hatter]
+    # branches: [trinity, neo, 7.1.x-docs, cheshire-cat, mad-hatter]
     start_path: docs
   # - url: https://git@github.com/couchbase/backup
   - url: https://github.com/couchbase/backup
     branches: [neo, 7.1.x-docs, cheshire-cat, mad-hatter]
+    # branches: [trinity, neo, 7.1.x-docs, cheshire-cat, mad-hatter]
     start_path: docs
   # NOTE docs-server is currently after other server repos so nav key wins
   - url: https://github.com/couchbase/docs-server

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -42,7 +42,7 @@ content:
   - url: https://github.com/couchbaselabs/docs-devex
     branches: [release/7.2, capella, elixir]
   - url: https://github.com/couchbaselabs/cb-swagger
-    branches: [release/7.2, release/7.1, release/7.0, release/6.6, release/6.5, capella, elixir]
+    branches: [release/7.2, release/7.1, release/7.0, release/6.6, capella, elixir]
     start_path: docs
   #- url: https://git@github.com/couchbasecloud/couchbase-cloud
   - url: https://github.com/couchbasecloud/couchbase-cloud
@@ -50,7 +50,7 @@ content:
     start_paths: [docs/public, docs/serverless]
   # - url: https://git@github.com/couchbase/couchbase-operator
   - url: https://github.com/couchbase/couchbase-operator
-    branches: [master, 2.4.x, 2.3.x, 2.2.x, 2.1.x, 2.0.x, 1.2.x, 1.1.x, 1.0.x]
+    branches: [master, 2.4.x, 2.3.x, 2.2.x, 2.1.x]
     start_path: docs/user
   - url: https://github.com/couchbaselabs/observability
     branches: [main]
@@ -59,13 +59,13 @@ content:
     branches: [master]
     start_path: docs
   - url: https://github.com/couchbase/couchbase-elasticsearch-connector
-    branches: [release/4.2, release/4.1, release/4.0]
+    branches: [master, release/4.3]
     start_path: docs
   - url: https://github.com/couchbase/kafka-connect-couchbase
-    branches: [master, release/4.0, release/3.4]
+    branches: [master]
     start_path: docs
   - url: https://github.com/couchbase/couchbase-spark-connector
-    branches: [master, release/3.1, release/3.0, release/2.4]
+    branches: [master, release/3.1, release/3.0]
     start_path: docs
   - url: https://github.com/couchbase/couchbase-tableau-connector
     branches: [master]
@@ -74,39 +74,39 @@ content:
   - url: https://github.com/couchbase/docs-connectors-talend
   # - url: https://git@github.com/couchbase/docs-analytics
   - url: https://github.com/couchbase/docs-analytics
-    branches: [release/7.2, release/7.1, release/7.0, release/6.6, release/6.5]
+    branches: [release/7.2, release/7.1, release/7.0, release/6.6]
   - url: https://github.com/couchbase/couchbase-cli
-    branches: [neo, 7.1.x-docs, cheshire-cat, mad-hatter, 6.5.x-docs]
+    branches: [neo, 7.1.x-docs, cheshire-cat, mad-hatter]
     start_path: docs
   # - url: https://git@github.com/couchbase/backup
   - url: https://github.com/couchbase/backup
-    branches: [neo, 7.1.x-docs, cheshire-cat, mad-hatter, 6.5.x-docs]
+    branches: [neo, 7.1.x-docs, cheshire-cat, mad-hatter]
     start_path: docs
   # NOTE docs-server is currently after other server repos so nav key wins
   - url: https://github.com/couchbase/docs-server
-    branches: [release/7.2, release/7.1, release/7.0, release/6.6, release/6.5]
+    branches: [release/7.2, release/7.1, release/7.0, release/6.6]
   - url: https://github.com/couchbase/docs-sdk-common
-    branches: [release/7.1.2, release/7.1, release/7.0, release/6.6, release/6.5]
+    branches: [release/7.1.2, release/7.1, release/7.0, release/6.6]
   - url: https://github.com/couchbase/docs-sdk-c
-    branches: [release/3.3, release/3.2, release/3.1, release/3.0]
+    branches: [release/3.3, release/3.2, release/3.1]
   - url: https://github.com/couchbase/docs-txn-cxx
     branches: [release/1.0]
   - url: https://github.com/couchbase/docs-sdk-dotnet
-    branches: [release/3.4, release/3.3, release/3.2, release/3.1, release/3.0]
+    branches: [release/3.4, release/3.3, release/3.2, release/3.1]
   - url: https://github.com/couchbase/docs-sdk-go
-    branches: [release/2.6, release/2.5, release/2.4, release/2.3, release/2.2, release/2.1]
+    branches: [release/2.6, release/2.5, release/2.4, release/2.3, release/2.2]
   - url: https://github.com/couchbase/docs-sdk-java
-    branches: [release/3.4, release/3.3, release/3.2, release/3.1, release/3.0]
+    branches: [release/3.4, release/3.3, release/3.2, release/3.1]
   - url: https://github.com/couchbase/docs-sdk-kotlin
     branches: [release/1.1, release/1.0]
   - url: https://github.com/couchbase/docs-sdk-nodejs
-    branches: [release/4.2, release/4.1, release/4.0, release/3.2, release/3.1, release/3.0]
+    branches: [release/4.2, release/4.1, release/4.0, release/3.2, release/3.1]
   - url: https://github.com/couchbase/docs-sdk-php
-    branches: [release/4.1, release/4.0, release/3.2, release/3.1, release/3.0]
+    branches: [release/4.1, release/4.0, release/3.2, release/3.1]
   - url: https://github.com/couchbase/docs-sdk-python
-    branches: [release/4.1, release/4.0, release/3.2, release/3.1, release/3.0]
+    branches: [release/4.1, release/4.0, release/3.2, release/3.1]
   - url: https://github.com/couchbase/docs-sdk-ruby
-    branches: [release/3.4, release/3.3, release/3.2, release/3.1, release/3.0]
+    branches: [release/3.4, release/3.3, release/3.2, release/3.1]
   - url: https://github.com/couchbase/docs-sdk-scala
     branches: [release/1.4, release/1.3, release/1.2, release/1.1]
   - url: https://github.com/couchbase/docs-sdk-extensions

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -40,9 +40,9 @@ content:
     branches: HEAD
     start_path: home
   - url: https://github.com/couchbaselabs/docs-devex
-    branches: [release/7.2, capella, elixir]
+    branches: [release/7.6, release/7.2, capella, elixir]
   - url: https://github.com/couchbaselabs/cb-swagger
-    branches: [release/7.2, release/7.1, release/7.0, release/6.6, capella, elixir]
+    branches: [release/7.6, release/7.2, release/7.1, release/7.0, release/6.6, capella, elixir]
     start_path: docs
   #- url: https://git@github.com/couchbasecloud/couchbase-cloud
   - url: https://github.com/couchbasecloud/couchbase-cloud
@@ -74,7 +74,7 @@ content:
   - url: https://github.com/couchbase/docs-connectors-talend
   # - url: https://git@github.com/couchbase/docs-analytics
   - url: https://github.com/couchbase/docs-analytics
-    branches: [release/7.2, release/7.1, release/7.0, release/6.6]
+    branches: [release/7.6, release/7.2, release/7.1, release/7.0, release/6.6]
   - url: https://github.com/couchbase/couchbase-cli
     branches: [neo, 7.1.x-docs, cheshire-cat, mad-hatter]
     start_path: docs
@@ -84,7 +84,7 @@ content:
     start_path: docs
   # NOTE docs-server is currently after other server repos so nav key wins
   - url: https://github.com/couchbase/docs-server
-    branches: [release/7.2, release/7.1, release/7.0, release/6.6]
+    branches: [release/7.6, release/7.2, release/7.1, release/7.0, release/6.6]
   - url: https://github.com/couchbase/docs-sdk-common
     branches: [release/7.1.2, release/7.1, release/7.0, release/6.6]
   - url: https://github.com/couchbase/docs-sdk-c


### PR DESCRIPTION
This PR updates the staging playbook so that we can start building server release/7.6 in docs-staging.

* Removes EOL versions from the staging playbook following #702 
* Adds `release/7.6` branches for  `docs-devex`, `cb-swagger`, `docs-analytics`, and `docs-server`
* Adds note about `trinity` branches for `backup` and `couchbase-cli`

Note that `trinity` branches for `backup` and `couchbase-cli` are not ready yet, so these will not be included in 7.6 staging builds to begin with. Will need a new PR to add these when ready.

Docs issue: [DOC-11173](https://issues.couchbase.com/browse/DOC-11173)