### PR TITLE
AV-56547: Revert Banner

### DIFF
--- a/home/modules/ROOT/partials/info-banner.adoc
+++ b/home/modules/ROOT/partials/info-banner.adoc
@@ -3,46 +3,9 @@
 //
 // This is linked from each of the Landing pages.
 // To *disable* it, simply comment out the text BELOW.
-//
-// See
-// https://couchbasecloud.atlassian.net/browse/AV-56547
-// for the original requirement.
-
-// NOTE: the following CSS will be moved to docs-ui once 
-// iterated and agreed.
-++++
-<style>
-.info-banner {
-    display: block;
-    border: 1px solid #e5e5e5;
-    border-radius: 3px;
-    -webkit-box-shadow: 0 3px 10px rgba(0,0,0,.06);
-    box-shadow: 0 3px 10px rgba(0,0,0,.06);
-    background-image: linear-gradient(to right, #00ace0, #636cdc);
-    padding: 0.75em;
-    margin-top: 0;
-    margin-bottom: 1em;
-
-}
-.doc.landing-page-doc .info-banner p {
-    text-align: center;
-    color: white;
-    font-weight: lighter;
-}
-.info-banner a {
-    color: white;
-    font-size: 18px;
-    font-weight: bold;
-    display: inline-block;
-    border: solid 1px white;
-    padding: 0.5em 1em;
-}
-</style>
-++++
 
 // NOTE: comment the paragraph below to hide the banner.
-[.info-banner]
-The Capella Spring release is here!
-Introducing developer integrations for Netlify and VSCode, and more.
-https://www.couchbase.com/blog/couchbase-capella-spring-release-72[Check it out]
 
+// [.info-banner]
+// Some exciting stuff is happening!
+// https://www.couchbase.com/example/link[Check it out]


### PR DESCRIPTION
revert the Capella Spring Banner.

NB: 
* the calling points are left in place, so it should be trivial to edit this file to re-add the banner at any point in future

* we remove the inline CSS, which will now be added to docs-ui in PR https://github.com/couchbase/docs-ui/pull/167