### PR TITLE
DOC-11173: Docs infrastructure for 7.6.0

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -76,12 +76,12 @@ content:
   - url: https://github.com/couchbase/docs-analytics
     branches: [release/7.6, release/7.2, release/7.1, release/7.0, release/6.6]
   - url: https://github.com/couchbase/couchbase-cli
-    branches: [neo, 7.1.x-docs, cheshire-cat, mad-hatter]
+    branches: [master, neo, 7.1.x-docs, cheshire-cat, mad-hatter]
     # branches: [trinity, neo, 7.1.x-docs, cheshire-cat, mad-hatter]
     start_path: docs
   # - url: https://git@github.com/couchbase/backup
   - url: https://github.com/couchbase/backup
-    branches: [neo, 7.1.x-docs, cheshire-cat, mad-hatter]
+    branches: [master, neo, 7.1.x-docs, cheshire-cat, mad-hatter]
     # branches: [trinity, neo, 7.1.x-docs, cheshire-cat, mad-hatter]
     start_path: docs
   # NOTE docs-server is currently after other server repos so nav key wins


### PR DESCRIPTION
Follow-up to #703. @jamesl33 has stated that the `master` branch is the branch for 7.6 development in the `backup` and `couchbase-cli` repos. I have updated the Antora component descriptors in these repos accordingly. This PR adds `master` branches for `backup` and `couchbase-cli` so that we can add these repos to builds of 7.6 on the staging site.

This is a temporary fix; we'll need to update these repos to use proper `trinity` branches when they become available.