### PR TITLE
SDK Workaround

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -87,7 +87,7 @@ content:
   - url: https://github.com/couchbase/docs-server
     branches: [release/7.2, release/7.1, release/7.0, release/6.6]
   - url: https://github.com/couchbase/docs-sdk-common
-    branches: [release/7.1.2, release/7.1, release/7.0, release/6.6]
+    branches: [release/7.1.2, release/7.1, release/7.0, release/6.6, release/6.5]
   - url: https://github.com/couchbase/docs-sdk-c
     branches: [release/3.3, release/3.2, release/3.1]
   - url: https://github.com/couchbase/docs-txn-cxx


### PR DESCRIPTION
Time-saving fix to legacy 6.5 includes in SDK 3.1.

In later versions a variable ensures the correct include::, but not in 3.1.