### PR TITLE
UI-170 docs site width fix

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -195,6 +195,6 @@ asciidoc:
   - '@asciidoctor/tabs'
 ui:
   bundle:
-    url: https://github.com/couchbase/docs-ui/releases/download/prod-169/ui-bundle.zip
+    url: https://github.com/couchbase/docs-ui/releases/download/prod-170/ui-bundle.zip
 output:
   dir: ./public


### PR DESCRIPTION
Currently being built onto staging, will be reviewable there from ~5pm UK Friday.
https://couchbasecloud.atlassian.net/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords for login.

See:
https://github.com/couchbase/docs-ui/commit/3b8b35ad6be0026688999eedbca9b92684248dd4

Regression from footer nav fix.
This update gives reasonable results (tested by eyeball) although 3-column landing page is still rather constrained between ~770-850px (but that may just require a flex box change on that specific page)