### PR TITLE
Fix mobile tutorials redirects

### DIFF
--- a/etc/nginx/snippets/rewrites.conf
+++ b/etc/nginx/snippets/rewrites.conf
@@ -93,8 +93,28 @@ location ^~ /prerelease/analytics-dp4/ { return 301 /server/current/analytics/in
 location ^~ /prerelease/couchbase-operator/beta/ { rewrite ^/prerelease/couchbase-operator/beta/(.*)$ /operator/current/$1 permanent; }
 # Evergreen link for Uninstall to be included in CB License
 location ^~ /manual/uninstall/ { return 301 /server/current/install/install-uninstalling.html; }
-# Tutorials no longer in docs, now in developer.couchbase.com/tutorials 
-location ^~ /tutorials/ { rewrite ^/tutorials/(.*)$ $scheme://developer.couchbase.com/tutorials/ redirect; }
+
+# Most Tutorials have now moved to developer.couchbase.com/tutorials
+# However some legacy tutorials exist for Mobile.
+location ^~ /tutorials/mobile-travel-tutorial/ { break; }
+location ^~ /tutorials/todo-app/ { break; }
+location ^~ /tutorials/userprofile-standalone/ { break; }
+location ^~ /tutorials/userprofile-query/ { break; }
+location ^~ /tutorials/userprofile-sync/ { break; }
+location ^~ /tutorials/userprofile-standalone-xamarin/ { break; }
+location ^~ /tutorials/userprofile-query-xamarin/ { break; }
+location ^~ /tutorials/userprofile-sync-xamarin/ { break; }
+location ^~ /tutorials/userprofile-standalone-android/ { break; }
+location ^~ /tutorials/userprofile-query-android/ { break; }
+location ^~ /tutorials/userprofile-sync-android/ { break; }
+location ^~ /tutorials/university-lister/ { break; }
+location ^~ /tutorials/tutorial-template/ { break; }
+location ^~ /tutorials/cbl-p2p-sync-websockets/ { break; }
+
+location ^~ /tutorials/ {
+    rewrite ^/tutorials/(.*)$ $scheme://developer.couchbase.com/tutorials/ redirect;
+}
+
 # Evergreen links for SDK API
 location ^~ /sdk-api/couchbase-c-client/ { rewrite ^/sdk-api/(couchbase-c-client)/(.*)$ /sdk-api/$1-$current_version_sdk_c_api/$2 last; }
 location ^~ /sdk-api/couchbase-cxx-client/ { rewrite ^/sdk-api/(couchbase-cxx-client)/(.*)$ /sdk-api/$1-$current_version_sdk_cxx_api/$2 last; }


### PR DESCRIPTION
Via https://www.couchbase.com/forums/t/documentation-of-travel-sample-app-not-found/36258/2

We redirect /tutorials/ to developer.couchbase.com but the mobile tutorials were never adopted.

Until these are also adopted, this commit does `break` for known tutorials, to prevent the following redirect.

Test that e.g. https://docs-staging.couchbase.com/tutorials/todo-app/ is 404 (rather than 302 redirect).

The tutorials are published to live, e.g. see
https://github.com/couchbase/docs-site/blob/master/antora-playbook.yml#L130-L157 but not staging, hence the 404.