### PR TITLE
Tutorials to S3 redirect

### DIFF
--- a/etc/nginx/snippets/rewrites.conf
+++ b/etc/nginx/snippets/rewrites.conf
@@ -118,20 +118,20 @@ location ^~ /manual/uninstall/ { return 301 /server/current/install/install-unin
 
 # Most Tutorials have now moved to developer.couchbase.com/tutorials
 # However some legacy tutorials exist for Mobile.
-location ^~ /tutorials/mobile-travel-tutorial/ { break; }
-location ^~ /tutorials/todo-app/ { break; }
-location ^~ /tutorials/userprofile-standalone/ { break; }
-location ^~ /tutorials/userprofile-query/ { break; }
-location ^~ /tutorials/userprofile-sync/ { break; }
-location ^~ /tutorials/userprofile-standalone-xamarin/ { break; }
-location ^~ /tutorials/userprofile-query-xamarin/ { break; }
-location ^~ /tutorials/userprofile-sync-xamarin/ { break; }
-location ^~ /tutorials/userprofile-standalone-android/ { break; }
-location ^~ /tutorials/userprofile-query-android/ { break; }
-location ^~ /tutorials/userprofile-sync-android/ { break; }
-location ^~ /tutorials/university-lister/ { break; }
-location ^~ /tutorials/tutorial-template/ { break; }
-location ^~ /tutorials/cbl-p2p-sync-websockets/ { break; }
+location ^~ /tutorials/mobile-travel-tutorial/         { proxy_pass $s3_bucket_uri$uri; break; }
+location ^~ /tutorials/todo-app/                       { proxy_pass $s3_bucket_uri$uri; break; }
+location ^~ /tutorials/userprofile-standalone/         { proxy_pass $s3_bucket_uri$uri; break; }
+location ^~ /tutorials/userprofile-query/              { proxy_pass $s3_bucket_uri$uri; break; }
+location ^~ /tutorials/userprofile-sync/               { proxy_pass $s3_bucket_uri$uri; break; }
+location ^~ /tutorials/userprofile-standalone-xamarin/ { proxy_pass $s3_bucket_uri$uri; break; }
+location ^~ /tutorials/userprofile-query-xamarin/      { proxy_pass $s3_bucket_uri$uri; break; }
+location ^~ /tutorials/userprofile-sync-xamarin/       { proxy_pass $s3_bucket_uri$uri; break; }
+location ^~ /tutorials/userprofile-standalone-android/ { proxy_pass $s3_bucket_uri$uri; break; }
+location ^~ /tutorials/userprofile-query-android/      { proxy_pass $s3_bucket_uri$uri; break; }
+location ^~ /tutorials/userprofile-sync-android/       { proxy_pass $s3_bucket_uri$uri; break; }
+location ^~ /tutorials/university-lister/              { proxy_pass $s3_bucket_uri$uri; break; }
+location ^~ /tutorials/tutorial-template/              { proxy_pass $s3_bucket_uri$uri; break; }
+location ^~ /tutorials/cbl-p2p-sync-websockets/        { proxy_pass $s3_bucket_uri$uri; break; }
 
 location ^~ /tutorials/ {
     rewrite ^/tutorials/(.*)$ $scheme://developer.couchbase.com/tutorials/ redirect;


### PR DESCRIPTION
`break` prevents the proxy_pass directive in the `default` site config. This workaround is inelegant but, well, works.