### PR TITLE
Global sitemap iteration

### DIFF
--- a/scripts/make-global-sitemap.sh
+++ b/scripts/make-global-sitemap.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+MANIFEST=${1-public/site-manifest.json}
+SITEMAP=${2-public/global-sitemap.xml}
+
+(
+cat <<HEADER
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+HEADER
+
+jq -r \
+    '(.generated / 1000 | todate) as $date |
+    .url as $url |
+
+    .components |
+    map(.versions[0]) |
+    map(.pages) |
+    flatten |
+    map("<url>" +
+        "<loc>" + $url + .url + "</loc>" +
+        "<lastmod>" + $date + "</lastmod>" + 
+        "</url>") | join("\n")' \
+    $MANIFEST
+
+echo '</urlset>'
+) > $SITEMAP


### PR DESCRIPTION
@leeming produced a global-sitemap.xml for @gsauere and support team that contains *all* files, which is excessive for their indexing.

To do this in Antora would require overriding the `siteMap` function, for example to export an additional sitemap that includes only the latest version.

This is possible within Antora, but the default site-mapper doesn't export its utility functions, so we'd have to duplicate some logic, which could be fragile to future Antora updates.

Looking back at a command-line approach, while the sitemap xml files don't contain enough metadata to easily tell which version is current, we have an overridden site-generator (pimped up by OpenDevise) which exports a site-manifest.json:

https://gitlab.com/opendevise/oss/antora-site-generator-ms/-/blob/v2.3.x/lib/export-site-manifest.js

Test locally with, for example:

`antora --clean local.yml && scripts/make-global-sitemap.sh && xmllint --format public/global-sitemap.xml`