### PR TITLE
2023 Rebrand: Update antora-playbook.yml to prod-178

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -194,6 +194,6 @@ asciidoc:
   - '@asciidoctor/tabs'
 ui:
   bundle:
-    url: https://github.com/couchbase/docs-ui/releases/download/prod-175/ui-bundle.zip
+    url: https://github.com/couchbase/docs-ui/releases/download/prod-178/ui-bundle.zip
 output:
   dir: ./public


### PR DESCRIPTION
Requires https://github.com/couchbase/docs-ui/pull/174 to be merged and prod-178 built against it.