### PR TITLE
[WIP] DOC-11819: remove playbook references to tutorials.

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -22,7 +22,6 @@ site:
         { "title": "Autonomous Operator", "components": ["operator"] },
         { "title": "CMOS", "components": ["cmos"] },
         { "title": "SDKs", "startPage": "home::sdk.adoc", "components": ["*-sdk", "cxx-txns", "elasticsearch-connector", "kafka-connector", "spark-connector", "tableau-connector", "power-bi-connector", "sdk-extensions"] },
-        { "title": "Tutorials", "startPage": "tutorials::index.adoc", "components": ["tutorials"] }
       ]
 git:
   ensure_git_suffix: false
@@ -124,18 +123,8 @@ content:
   # - url: https://git@github.com/couchbase/docs-cloud-native
   - url: https://github.com/couchbase/docs-cloud-native
     branches: [cloud-native-2.2]
-#  - url: https://github.com/couchbaselabs/tutorials
-  - url: https://github.com/couchbase/developer-content
-  - url: https://github.com/couchbaselabs/tutorial-template
-  - url: https://github.com/couchbaselabs/mobile-travel-sample
-    branches: [master]
-    start_path: content
   # - url: https://github.com/couchbaselabs/hotel-finder-react-native
   # - url: https://github.com/couchbaselabs/hotel-lister-cordova
-#  - url: https://github.com/couchbaselabs/tutorials-contrib
-  - url: https://github.com/couchbaselabs/mobile-training-todo
-    branches: tutorials
-    start_path: content
   - url: https://github.com/couchbaselabs/UniversityLister-Android
     start_path: content
   - url: https://github.com/couchbaselabs/userprofile-couchbase-mobile


### PR DESCRIPTION
This is an attempt to fix the following ticket: https://issues.couchbase.com/browse/DOC-11819

https://docs.couchbase.com/tutorials/userprofile-query-android/userprofile_query.html

https://docs.couchbase.com/tutorials/mobile-travel-tutorial/swift/installation/travel-mobile-app.html

On triaging: https://issues.couchbase.com/browse/DOC-10798

I discovered a few orphan pages, it is my understanding that tutorials have moved to the developer advocacy side which would explain the broken appearance of the pages (screenshots attached). No nav bars being one reason.