### PR TITLE
AV-69258 SEO disallow old SDK API docs

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -10,7 +10,15 @@ site:
   title: Couchbase Docs
   url: https://docs.couchbase.com
   start_page: home::index.adoc
-  robots: allow
+  robots: |
+    User-agent: *
+    Allow: /sdk-api/*-client/
+    Allow: /sdk-api/couchbase-core-io/
+    Allow: /sdk-api/couchbase-transactions-java/
+    Allow: /sdk-api/couchbase-transactions-cxx/
+    Allow: /sdk-api/couchbase-transactions-dotnet/
+    Disallow: /sdk-api/*
+    Allow: /
   keys:
     google_analytics: GTM-MVPNN2
     nav_groups: |


### PR DESCRIPTION
Update the robots to:

(rules checked in order)

1. Allow certain entries defined in https://github.com/couchbase/docs-site/blob/master/etc/nginx/snippets/rewrites.conf under "Evergreen links for SDK API" These links DON'T include a version number, and always point to the most current version.

Includes /*-client/ and 4 hardcoded entries.
This list would have to be manually updated if new SDKs/clients are added.

2. Disallow all other entries under /sdk-api/ (and specifically the versioned docs like /*-client-1.2.3/

3. Allow everything else (fallback rule)

NOTE: this solution should work only for SDK.
Mobile doesn't (yet) have the concept of Evergreen link rewrites, but we could add this in a subsequent step.