### PR TITLE
DOC-11976: server 7.6 GA

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -45,9 +45,9 @@ content:
     start_paths: [styleguide, ui-ux, pendo]
   - url: https://github.com/couchbaselabs/docs-devex
     # branches: [release/7.2, capella, elixir]
-    branches: [release/7.2, capella]
+    branches: [release/7.6, release/7.2, capella]
   - url: https://github.com/couchbaselabs/cb-swagger
-    branches: [release/7.2, release/7.1, release/7.0]
+    branches: [release/7.6, release/7.2, release/7.1, release/7.0]
     start_path: docs
   # - url: https://git@github.com/couchbasecloud/couchbase-cloud
   - url: https://github.com/couchbasecloud/couchbase-cloud
@@ -81,17 +81,17 @@ content:
   - url: https://github.com/couchbase/docs-connectors-talend
   # - url: https://git@github.com/couchbase/docs-analytics
   - url: https://github.com/couchbase/docs-analytics
-    branches: [release/7.2, release/7.1, release/7.0]
+    branches: [release/7.6, release/7.2, release/7.1, release/7.0]
   - url: https://github.com/couchbase/couchbase-cli
-    branches: [neo, 7.1.x-docs, cheshire-cat]
+    branches: [trinity, neo, 7.1.x-docs, cheshire-cat]
     start_path: docs
   # - url: https://git@github.com/couchbase/backup
   - url: https://github.com/couchbase/backup
-    branches: [neo, 7.1.x-docs, cheshire-cat]
+    branches: [trinity, neo, 7.1.x-docs, cheshire-cat]
     start_path: docs
   # NOTE docs-server is currently after other server repos so nav key wins
   - url: https://github.com/couchbase/docs-server
-    branches: [release/7.2, release/7.1, release/7.0]
+    branches: [release/7.6, release/7.2, release/7.1, release/7.0]
   - url: https://github.com/couchbase/docs-sdk-common
     branches: [temp/7.5, release/7.2, release/7.1.2, release/7.1, release/7.0, release/6.6, release/6.5]
   - url: https://github.com/couchbase/docs-sdk-c
@@ -197,6 +197,6 @@ asciidoc:
   - '@asciidoctor/tabs'
 ui:
   bundle:
-    url: https://github.com/couchbase/docs-ui/releases/download/prod-179/ui-bundle.zip
+    url: https://github.com/couchbase/docs-ui/releases/download/prod-183/ui-bundle.zip
 output:
   dir: ./public

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -113,7 +113,7 @@ content:
   - url: https://github.com/couchbase/docs-sdk-python
     branches: [temp/4.2, release/4.1, release/4.0]
   - url: https://github.com/couchbase/docs-sdk-ruby
-    branches: [release/3.4, release/3.3]
+    branches: [temp/3.5, release/3.4, release/3.3]
   - url: https://github.com/couchbase/docs-sdk-scala
     branches: [temp/1.6, release/1.5, release/1.4, release/1.3]
   - url: https://github.com/couchbase/docs-sdk-extensions


### PR DESCRIPTION
Add 7.6 branches (or `trinity` for those repos that use that convention).

Update UI bundle for Metrics display.