### PR TITLE
AV-69254 robots.txt for SDK 4xx

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -10,7 +10,15 @@ site:
   title: Couchbase Docs
   url: https://docs.couchbase.com
   start_page: home::index.adoc
-  robots: allow
+  robots: |
+    User-agent: *
+    Allow: /
+    Disallow: /sdk-api/
+    Allow: /sdk-api/*-client/
+    Allow: /sdk-api/*-core-api/
+    Allow: /sdk-api/couchbase-transactions-java/
+    Allow: /sdk-api/couchbase-transactions-cxx/
+    Allow: /sdk-api/couchbase-transactions-dotnet/
   keys:
     google_analytics: GTM-MVPNN2
     nav_groups: |

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -15,7 +15,7 @@ site:
     Allow: /
     Disallow: /sdk-api/
     Allow: /sdk-api/*-client/
-    Allow: /sdk-api/*-core-api/
+    Allow: /sdk-api/couchbase-core-io/
     Allow: /sdk-api/couchbase-transactions-java/
     Allow: /sdk-api/couchbase-transactions-cxx/
     Allow: /sdk-api/couchbase-transactions-dotnet/

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -16,7 +16,6 @@ site:
     Disallow: /sdk-api/
     Allow: /sdk-api/*-client/
     Allow: /sdk-api/couchbase-core-io/
-    Allow: /sdk-api/couchbase-transactions-java/
     Allow: /sdk-api/couchbase-transactions-cxx/
     Allow: /sdk-api/couchbase-transactions-dotnet/
   keys:


### PR DESCRIPTION
The SEO audit flagged a number of 4xx results.
Many of those are for API docs, generated by devs, and uploaded to our S3 bucket. Most of the 4xx errors are for *old* API docs, generated in the past using potentially old SDK docs toolchains. It may be awkward for devs to regenerate historical API docs.

This robots.txt change prevents crawlers such as Googlebot from indexing the OLD SDK API docs, which we hope should have a knock-on effect in reducing the number of 4xx errors generated.

We rely on the Evergreen links in https://github.com/couchbase/docs-site/blob/master/etc/nginx/snippets/rewrites.conf#L164-L181 which mean that e.g. https://docs.couchbase.com/sdk-api/couchbase-scala-client/ will transparently show (at current time) https://docs.couchbase.com/sdk-api/couchbase-scala-client-1.6.0/

These Evergreen links are the ones linked from https://docs.couchbase.com/home/sdk.html so will be crawled (the robots.txt should allow them).

The API docs are *also* linked from e.g. the Release Notes https://docs.couchbase.com/ruby-sdk/current/project-docs/sdk-release-notes.html but these point to the numbered versions (which the Robots.txt should deny).

TESTING
=======

We can copy the robots.txt text in this commit to e.g. https://technicalseo.com/tools/robots-txt/

And test against various URLS:

ALLOW
- https://docs.couchbase.com/home/index.html
- https://docs.couchbase.com/sdk-api/couchbase-c-client/
- https://docs.couchbase.com/sdk-api/couchbase-cxx-client/
- https://docs.couchbase.com/sdk-api/couchbase-net-client/
- https://docs.couchbase.com/sdk-api/couchbase-go-client/
- https://docs.couchbase.com/sdk-api/couchbase-java-client/ 
- https://docs.couchbase.com/sdk-api/couchbase-core-io/ 
- https://docs.couchbase.com/sdk-api/couchbase-kotlin-client/ 
- https://docs.couchbase.com/sdk-api/couchbase-node-client/ 
- https://docs.couchbase.com/sdk-api/couchbase-php-client/ 
- https://docs.couchbase.com/sdk-api/couchbase-python-client/ 
- https://docs.couchbase.com/sdk-api/couchbase-ruby-client/ 
- https://docs.couchbase.com/sdk-api/couchbase-scala-client/ 
- https://docs.couchbase.com/sdk-api/couchbase-transactions-java/ 
- https://docs.couchbase.com/sdk-api/couchbase-transactions-cxx/ 
- https://docs.couchbase.com/sdk-api/couchbase-transactions-dotnet/

DISALLOW
- https://docs.couchbase.com/sdk-api/couchbase-c-client-1.2.3/ 
- https://docs.couchbase.com/sdk-api/couchbase-cxx-client-1.2.3/ 
- https://docs.couchbase.com/sdk-api/couchbase-net-client-1.2.3/ 
- https://docs.couchbase.com/sdk-api/couchbase-go-client-1.2.3/ 
- https://docs.couchbase.com/sdk-api/couchbase-java-client-1.2.3/ 
- https://docs.couchbase.com/sdk-api/couchbase-core-io-1.2.3/ 
- https://docs.couchbase.com/sdk-api/couchbase-kotlin-client-1.2.3/ 
- https://docs.couchbase.com/sdk-api/couchbase-node-client-1.2.3/ 
- https://docs.couchbase.com/sdk-api/couchbase-php-client-1.2.3/ 
- https://docs.couchbase.com/sdk-api/couchbase-python-client-1.2.3/ 
- https://docs.couchbase.com/sdk-api/couchbase-ruby-client-1.2.3/ 
- https://docs.couchbase.com/sdk-api/couchbase-scala-client-1.2.3/ 
- https://docs.couchbase.com/sdk-api/couchbase-transactions-java-1.2.3/ 
- https://docs.couchbase.com/sdk-api/couchbase-transactions-cxx-1.2.3/ 
- https://docs.couchbase.com/sdk-api/couchbase-transactions-dotnet-1.2.3/

We can run the same URLs against a "Live" test once deployed.