### PR TITLE
DOC-12133 update page-embargo functionality

### DIFF
--- a/lib/embargo.js
+++ b/lib/embargo.js
@@ -10,11 +10,8 @@ module.exports.register = function ({ config }) {
             .forEach((page) => {
               if (page.asciidoc.attributes['page-embargo'] != null) {
                 console.log("Embargoed", page.pub.url, page.asciidoc.attributes['page-embargo'])
-                delete page.pub
-                delete page.out
-                // contentCatalog.removeFile(page)
+                contentCatalog.removeFile(page)
               }
-
             })
         })
       })


### PR DESCRIPTION
Via Simon Dew, a page with page-aliases breaks page-embargo.

Looking at original commit, we were manually deleting page.pub etc. because the contentCatalog method was only present in Antora 3.1.1 and onwards. see 13190cefc6891db7500d086a1ddd09f13bb64bab

As we're now upgraded, we can substitute this in.