### PR TITLE
DOC-10865: Migrate settings reference to docs-devex

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -55,7 +55,7 @@ content:
     # branches: [release/7.2, capella, elixir]
     branches: [release/7.6, release/7.2, capella]
   - url: https://github.com/couchbaselabs/cb-swagger
-    branches: [release/7.6, release/7.2, release/7.1, release/7.0]
+    branches: [release/7.6, release/7.2, release/7.1, release/7.0, capella]
     start_path: docs
   # - url: https://git@github.com/couchbasecloud/couchbase-cloud
   - url: https://github.com/couchbasecloud/couchbase-cloud


### PR DESCRIPTION
Docs issue: DOC-10865

In the Server docs, the descriptions of the request-level settings are taken automatically from the Query Service REST API reference. I am assuming that, ultimately, the descriptions of request-level settings for Capella will be automatically generated from the Data API reference. However, the Data API is still in development.

As a temporary measure, this PR adds a cut-down version of the Query Service REST API to the (hitherto unused) `capella` branch of the cb-swagger docs, purely so that it can be used to generate descriptions of request-level settings for Capella.

⚠️ This change must be merged at the same time as the following related PRs:

* https://github.com/couchbaselabs/docs-devex/pull/216
* https://github.com/couchbasecloud/couchbase-cloud/pull/30942
* https://github.com/couchbasecloud/couchbase-cloud/pull/30942

