### PR TITLE
SEO-changes-map-302-to-301

### DIFF
--- a/etc/nginx/snippets/rewrites.conf
+++ b/etc/nginx/snippets/rewrites.conf
@@ -18,5 +18,6 @@ location ^~ /tutorials/tutorial-template/ { break; }
 location ^~ /tutorials/cbl-p2p-sync-websockets/ { break; }
 
 location ^~ /tutorials/ {
-    rewrite ^/tutorials/(.*)$ $scheme://developer.couchbase.com/tutorials/ redirect;
+    rewrite ^/tutorials/(.*)$ $scheme://developer.couchbase.com/tutorials/ permanent;
 }
+


### PR DESCRIPTION
Test change to map 302 redirections to 301, which should allow them to be indexed by search engines. Testing on Staging first, in case it breaks.