### PR TITLE
AV-56565: add page-rank attribute

### DIFF
--- a/antora-playbook-staging.yml
+++ b/antora-playbook-staging.yml
@@ -176,6 +176,7 @@ asciidoc:
     tabs-sync-option: ''
     toc: ~
     page-toclevels: 1@
+    page-rank: 50@
     xrefstyle: short
     enterprise: https://www.couchbase.com/products/editions[ENTERPRISE EDITION]
     community: https://www.couchbase.com/products/editions[COMMUNITY EDITION]
@@ -197,6 +198,6 @@ asciidoc:
   - '@asciidoctor/tabs'
 ui:
   bundle:
-    url: https://github.com/couchbase/docs-ui/releases/download/staging-9/ui-bundle.zip
+    url: https://github.com/couchbase/docs-ui/releases/download/staging-10/ui-bundle.zip
 output:
   dir: ./public

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -179,6 +179,7 @@ asciidoc:
     tabs-sync-option: ''
     toc: ~
     page-toclevels: 1@
+    page-rank: 50@
     xrefstyle: short
     enterprise: https://www.couchbase.com/products/editions[ENTERPRISE EDITION]
     community: https://www.couchbase.com/products/editions[COMMUNITY EDITION]
@@ -206,6 +207,6 @@ asciidoc:
   - '@asciidoctor/tabs'
 ui:
   bundle:
-    url: https://github.com/couchbase/docs-ui/releases/download/prod-186/ui-bundle.zip
+    url: https://github.com/couchbase/docs-ui/releases/download/prod-189/ui-bundle.zip
 output:
   dir: ./public

--- a/home/antora.yml
+++ b/home/antora.yml
@@ -1,8 +1,9 @@
 name: home
-title: Writer's Guide
+title: Couchbase Documentation
 version: master
 nav:
 - modules/contribute/nav.adoc
 asciidoc:
   attributes:
     out-of-date: This documentation is out of date
+    page-rank: 0@

--- a/home/modules/ROOT/pages/cloud.adoc
+++ b/home/modules/ROOT/pages/cloud.adoc
@@ -1,6 +1,7 @@
 = Couchbase on Containers, Kubernetes, and Cloud
 :page-layout: landing-page-top-level-sdk
 :page-role: tiles
+:page-rank: 75
 :!sectids:
 
 include::partial$info-banner.adoc[]

--- a/home/modules/ROOT/pages/index.adoc
+++ b/home/modules/ROOT/pages/index.adoc
@@ -2,6 +2,7 @@
 :page-meta-zd-site-verification: odvin2siwmodz30xrtxq
 :page-layout: landing-page-top-level-sdk
 :page-role: tiles
+:page-rank: 75
 :!sectids:
 :collapsible:
 

--- a/home/modules/ROOT/pages/integrations.adoc
+++ b/home/modules/ROOT/pages/integrations.adoc
@@ -1,6 +1,7 @@
 = Big Data Integration Using Couchbase Connectors
 :page-layout: landing-page-top-level-sdk
 :page-role: tiles
+:page-rank: 75
 :!sectids:
 
 include::partial$info-banner.adoc[]

--- a/home/modules/ROOT/pages/mobile.adoc
+++ b/home/modules/ROOT/pages/mobile.adoc
@@ -1,6 +1,7 @@
 = Couchbase Mobile - Embedded Database on the Edge
 :page-layout: landing-page-top-level-sdk
 :page-role: tiles
+:page-rank: 75
 :!sectids:
 
 include::partial$info-banner.adoc[]

--- a/home/modules/ROOT/pages/sdk.adoc
+++ b/home/modules/ROOT/pages/sdk.adoc
@@ -2,6 +2,7 @@
 :page-aliases: sdks:intro.adoc,7.0@server:sdk:overview.adoc,7.1@server:sdk:overview.adoc,7.2@server:sdk:overview.adoc,7.6@server:sdk:overview.adoc,7.0@server:install:install-client-server.adoc,7.1@server:install:install-client-server.adoc,7.2@server:install:install-client-server.adoc,7.6@server:install:install-client-server.adoc
 :page-layout: landing-page-top-level-sdk
 :page-role: tiles
+:page-rank: 75
 :!sectids:
 
 include::partial$info-banner.adoc[]

--- a/home/modules/ROOT/pages/server.adoc
+++ b/home/modules/ROOT/pages/server.adoc
@@ -1,6 +1,7 @@
 = Couchbase Server
 :page-layout: landing-page-top-level-sdk
 :page-role: tiles
+:page-rank: 75
 :!sectids:
 :tabs:
 


### PR DESCRIPTION
For tweaking the search results, as follows:

  50  the default for all pages, in the middle of the 0-100 range.
   0  the writer's guide, to avoid promoting pages above more relevant content
  75  each landing page, to promote it for the "no query" case.

The playbook and antora.yml cases are overrideable (@), allowing us to tweak each page individually.

UI is set to latest version which exposes `<meta name=docsearch:page_rank>` based on these values, such that Algolia will pick them up.