### PR TITLE
[AV-60739] Attributes for Day 0 Docs

### DIFF
--- a/antora-playbook-staging.yml
+++ b/antora-playbook-staging.yml
@@ -183,6 +183,8 @@ asciidoc:
     sqlpp: SQL++
     sqlpp_url: https://www.couchbase.com/products/n1ql
     cbpp: Couchbase++
+    db: cluster
+    cptl-db: Cluster
     kroki-server-url: http://3.91.133.254:9500
     kroki-fetch-diagram: true
   extensions:

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -189,6 +189,8 @@ asciidoc:
     sqlppc: SQL++ for Capella columnar
     sqlpp_url: https://www.couchbase.com/products/n1ql
     cbpp: Couchbase++
+    db: cluster
+    cptl-db: Cluster
     kroki-server-url: http://3.91.133.254:9500
     kroki-fetch-diagram: true
     # the url-issues and url-issues-* attributes configure the URLs for the inline jira macro


### PR DESCRIPTION
Adding necessary {db} and {cptl-db} attributes to playbooks for building docs after Day 0 updates. 

Will make the future transition onto "operational database" much easier, if that ends up being the final decision. 