### PR TITLE
quickfix: make fetch default in playbook

### DIFF
--- a/antora-playbook-staging.yml
+++ b/antora-playbook-staging.yml
@@ -198,3 +198,5 @@ ui:
     url: https://github.com/couchbase/docs-ui/releases/download/preserve-hash-on-version-change-1/ui-bundle.zip
 output:
   dir: ./public
+runtime:
+  fetch: true

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -207,3 +207,5 @@ ui:
     url: https://github.com/couchbase/docs-ui/releases/download/prod-191/ui-bundle.zip
 output:
   dir: ./public
+runtime:
+  fetch: true


### PR DESCRIPTION
Make Antora fetch remote updates to repositories:
  https://docs.antora.org/antora/latest/playbook/runtime-fetch/

This will be a No-Op in most builds as:

	* for Github Actions/Jenkins build, the environment is generated completely fresh every time, and Antora will always fetch the latest content in this case.

	* most writers working locally will point to local repos, where this statement does nothing

So... what's the point? Well, the master playbooks are a resource that writers often copy, and having this as a default will help in the case that:

	* Locally, you build with a remote repo, and don't update changes, leading to confusion and the gnashing of teeth.

(Those writers who use that workflow regularly have already added this to their playbooks, or have aliased antora to always use `--fetch`. But it confuses the rest of us who don't do this regularly.)