### PR TITLE
AV-82275: Add columnar Management API Guide

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -77,7 +77,7 @@ asciidoc:
     cbpp: Couchbase++
     kroki-server-url: http://3.91.133.254:9500
     kroki-fetch-diagram: true
-    # flag-devex-escape-hatch: '@'
+    flag-columnar-escape-hatch: '@'
     # the url-issues and url-issues-* attributes configure the URLs for the inline jira macro
     url-issues: https://issues.couchbase.com/browse
     url-issues-jscbc: https://issues.couchbase.com/browse


### PR DESCRIPTION
We don't want the signpost and escape hatch to appear in the Capella operational docs until the Capella columnar docs have been published. For the moment, therefore, I've hidden the signpost and escape hatch behind a feature flag.

This PR _enables_ the feature flag for the columnar preview build, so that the signpost and escape hatch do appear in the Capella documentation for the columnar preview.

This must be merged at the same time as the following PR:

* https://github.com/couchbase/docs-capella/pull/38