### PR TITLE
DOC-12390 update trademark language

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -206,7 +206,7 @@ asciidoc:
   - '@asciidoctor/tabs'
 ui:
   bundle:
-    url: https://github.com/couchbase/docs-ui/releases/download/prod-198/ui-bundle.zip
+    url: https://github.com/couchbase/docs-ui/releases/download/prod-199/ui-bundle.zip
 output:
   dir: ./public
 runtime:


### PR DESCRIPTION
New trademark wording via @jleatherCB 
Preview at https://preview.docs-test.couchbase.com/hakim.yml/home/index.html
(password at https://couchbasecloud.atlassian.net/wiki/spaces/DOCS/pages/1971224949/Docs+Team+demo+site+passwords )

The change is already in docs-ui 199 via https://github.com/couchbase/docs-ui/commit/e9306a92bf5d424b88b45be4e2a203e0fcaa0a23

This change to docs-site just points to new bundle prod-199

![image](https://github.com/user-attachments/assets/f3fe90a8-d30b-4e80-8c64-60188b4c17f2)

