### PR TITLE
Update antora-playbook-staging.yml for operator 2.7 / 2.8

### DIFF
--- a/antora-playbook-staging.yml
+++ b/antora-playbook-staging.yml
@@ -59,7 +59,7 @@ content:
   - url: https://github.com/couchbase/docs-capella
     branches: [main]
   - url: https://github.com/couchbase/couchbase-operator
-    branches: [master, 2.6.x, 2.5.x, 2.4.x, 2.3.x, 2.2.x, 2.1.x]
+    branches: [master, 2.7.x, 2.6.x, 2.5.x, 2.4.x, 2.3.x]
     start_path: docs/user
   - url: https://github.com/couchbaselabs/observability
     branches: [main]


### PR DESCRIPTION
This must not be merged before confirmation from @malarky that master branch has been moved to track 2.8!

e.g. see https://github.com/couchbase/couchbase-operator/blob/master/docs/user/antora.yml#L3