### PR TITLE
[AV-82442] Update for Free Tier - Capella Homepage

### DIFF
--- a/home/modules/ROOT/pages/cloud.adoc
+++ b/home/modules/ROOT/pages/cloud.adoc
@@ -24,7 +24,7 @@ Capella columnar is a standalone, cloud-only offering from Couchbase under the C
 [.card-box]
 === icon:rocket[] Get Started With Capella Operational
 
-Get set up and ready with a free trial.
+Get set up with an account and deploy a free tier operational cluster.
 
 * https://cloud.couchbase.com/sign-up[Sign Up^]
 * xref:cloud:get-started:intro.adoc[]


### PR DESCRIPTION
Adjusted an a line in the Capella homepage with free tier updates. Changed "free trial" with "free tier". 

<img width="417" alt="Screenshot 2024-09-03 at 3 00 27 PM" src="https://github.com/user-attachments/assets/e56bc505-7be7-4708-9ece-78662bb42e39">
