### PR TITLE
upgrade doc site ui to 203

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -206,7 +206,7 @@ asciidoc:
   - '@asciidoctor/tabs'
 ui:
   bundle:
-    url: https://github.com/couchbase/docs-ui/releases/download/prod-202/ui-bundle.zip
+    url: https://github.com/couchbase/docs-ui/releases/download/prod-203/ui-bundle.zip
 output:
   dir: ./public
 runtime:


### PR DESCRIPTION
Updated the `antora-playbook.yml` file to reference the `prod-203` site UI.