### PR TITLE
DOC-12091: Add Analytics reference to Capella

### DIFF
--- a/antora-playbook-prerelease.yml
+++ b/antora-playbook-prerelease.yml
@@ -83,7 +83,7 @@ content:
   - url: https://github.com/couchbase/docs-connectors-talend
   # - url: https://git@github.com/couchbase/docs-analytics
   - url: https://github.com/couchbase/docs-analytics
-    branches: [release/7.6, release/7.2]
+    branches: [release/7.6, release/7.2, capella]
   - url: https://github.com/couchbase/couchbase-cli
     branches: [trinity, neo]
     start_path: docs

--- a/antora-playbook-staging.yml
+++ b/antora-playbook-staging.yml
@@ -82,7 +82,7 @@ content:
   - url: https://github.com/couchbase/docs-connectors-talend
   # - url: https://git@github.com/couchbase/docs-analytics
   - url: https://github.com/couchbase/docs-analytics
-    branches: [release/7.6, release/7.2, release/7.1, release/7.0]
+    branches: [release/7.6, release/7.2, release/7.1, release/7.0, capella]
   - url: https://github.com/couchbase/couchbase-cli
     branches: [trinity, neo, 7.1.x-docs, cheshire-cat]
     start_path: docs

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -88,7 +88,7 @@ content:
   - url: https://github.com/couchbase/docs-connectors-talend
   # - url: https://git@github.com/couchbase/docs-analytics
   - url: https://github.com/couchbase/docs-analytics
-    branches: [release/7.6, release/7.2, release/7.1, release/7.0]
+    branches: [release/7.6, release/7.2, release/7.1, release/7.0, capella]
   - url: https://github.com/couchbase/couchbase-cli
     branches: [trinity, neo, 7.1.x-docs, cheshire-cat]
     start_path: docs


### PR DESCRIPTION
Docs issue: [DOC-12091](https://jira.issues.couchbase.com/browse/DOC-12091)

This PR adds the Analytics reference guide to the Capella operational documentation. For historical reasons, the Analytics developer documentation is in its own repo, `docs-analytics`. This PR adds the `capella` branch of that repo to the build.

This effort was timeboxed, and I ran out of time to complete it, so parking my progress here.

Docs preview: [Analyze Large Datasets](https://preview.docs-test.couchbase.com/DOC-12091/cloud/clusters/analytics-service/analytics-service.html)
Credentials: [Preview docs for internal review](https://couchbasecloud.atlassian.net/wiki/x/dYF_dQ#Preview-docs-for-internal-review)

This can't be merged until the following linked PRs are ready:

- https://github.com/couchbase/docs-capella/pull/107
- https://github.com/couchbase/docs-analytics/pull/45

[DOC-12091]: https://couchbasecloud.atlassian.net/browse/DOC-12091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ