### PR TITLE
Revert "antora-playbook-staging.yml to prerelease/7.6.4"

### DIFF
--- a/antora-playbook-staging.yml
+++ b/antora-playbook-staging.yml
@@ -50,9 +50,9 @@ content:
     branches: main
     start_paths: [styleguide, ui-ux, pendo]
   - url: https://github.com/couchbaselabs/docs-devex
-    branches: [prerelease/7.6.4, release/7.2, capella, elixir]
+    branches: [release/7.6, release/7.2, capella, elixir]
   - url: https://github.com/couchbaselabs/cb-swagger
-    branches: [prerelease/7.6.4, release/7.2, release/7.1, release/7.0, capella]
+    branches: [release/7.6, release/7.2, release/7.1, release/7.0, capella]
     start_path: docs
   - url: https://github.com/couchbasecloud/couchbase-cloud
     branches: [main]
@@ -92,7 +92,7 @@ content:
     start_path: docs
   # NOTE docs-server is currently after other server repos so nav key wins
   - url: https://github.com/couchbase/docs-server
-    branches: [prerelease/7.6.4, release/7.2, release/7.1, release/7.0]
+    branches: [release/7.6, release/7.2, release/7.1, release/7.0]
   - url: https://github.com/couchbase/docs-sdk-common
     branches: [release/7.6, temp/7.5, release/7.2, release/7.1.2, release/7.1, release/7.0, release/6.6, release/6.5]
   - url: https://github.com/couchbase/docs-sdk-c


### PR DESCRIPTION
After Couchbase Server 7.6.4 is released, all the `prerelease/7.6.4` branches will disappear. This will break the staging build.

This PR reverts couchbase/docs-site#801 in order to reinstate the `release/7.6` branches for all necessary repos.