### PR TITLE
Warn on undefined repo in ext.preview.sources

### DIFF
--- a/lib/preview.js
+++ b/lib/preview.js
@@ -32,17 +32,8 @@ module.exports.register = function () {
     const sources = getSources(playbook, additionalSources)
     const source = sources[args.repo]
     if (! source) {
-        throw new Error(
-`Oh no! ${args.repo} source not found in playbook.
-You need to add to 'antora-playbook.preview.yml' something like:
-
-content:
-  sources:
-  # add in the appropriate place
-  - url: ${args.githubRemote || 'the appropriate github code URL'}
-    branches: ${args.branch}
-    ${args.startPath != '.' ? `start_path: ${args.startPath}\n` : ''}`)
-        }
+        throw notfound(args)
+    }
 
     if (args.remote) {
         // on CI only, download the source
@@ -106,7 +97,17 @@ content:
             (filteredSources, 
             desiredSources)
 
-    const urlMapper = ([k,v]) => [k, {...v, url: mapLocalUrl(k, v.url)}]
+    const urlMapper = ([k,v]) => {
+        if (! v.url) {
+            throw notfound({...args,
+                repo: k,
+                githubRemote: undefined,
+                branch: undefined,
+                startPath: '.'
+             })
+        }
+        return [k, {...v, url: mapLocalUrl(k, v.url)}]
+    }
 
     const mappedSources = 
         Object.values(
@@ -137,6 +138,19 @@ content:
     playbook.env = env
     this.updateVariables({ playbook })
   })
+}
+
+function notfound(args) {
+    return new Error(
+        `Oh no! ${args.repo} source not found in playbook.
+        You need to add to 'antora-playbook.preview.yml' something like:
+
+        content:
+          sources:
+          # add in the appropriate place
+          - url: ${args.githubRemote || 'the appropriate github URL'}
+            branches: ${args.branch || 'the appropriate default git branch'}
+            ${args.startPath != '.' ? `start_path: ${args.startPath}\n` : ''}`)
 }
 
 function getOverride(overridePlaybook) {


### PR DESCRIPTION
We already warned when the *current* content directory is not defined in antora-playbook.preview.yml.
But we didn't trap this error nicely in the ext.preview.sources case.

This commit extracts the `notfound` function so that both paths can throw a consistent error. (Of course the new case doesn't have all the information, so is a little hand-wavey...)