### PR TITLE
DOC-13085 extracted Operator to docs-operator

### DIFF
--- a/antora-playbook-staging.yml
+++ b/antora-playbook-staging.yml
@@ -64,7 +64,7 @@ content:
     branches: [main]
 
   # Operator unbundling test:
-  - url: https://github.com/osfameron/couchbase-operator # Hakim's fork 
+  - url: https://github.com/couchbase/couchbase-operator
     branches: [master, 2.8.x, 2.7.x, 2.6.x, 2.5.x, 2.4.x]
     start_path: docs/user
   - url: https://github.com/couchbase/docs-operator

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -62,9 +62,16 @@ content:
     branches: [main]
   - url: https://github.com/couchbaselabs/docs-columnar
     branches: [main]
+
+  # Couchbase Autonomous Kubernetes Operator
+  # Generated content remains in monorepo
+  # handwritten in docs-operator.
   - url: https://github.com/couchbase/couchbase-operator
     branches: [2.8.x, 2.7.x, 2.6.x, 2.5.x, 2.4.x]
     start_path: docs/user
+  - url: https://github.com/couchbase/docs-operator
+    branches: [release/2.8, release/2.7, release/2.6, release/2.5, release/2.4]
+
   - url: https://github.com/couchbaselabs/observability
     branches: [0.2.x]
     start_path: docs


### PR DESCRIPTION
* `couchbase-operator` remains the source of truth for *generated* content built from dev artefacts.

* `docs-operator` contains all the handwritten docs, extracted from the monorepo.

Marked as DRAFT to merge only after Gerrit approval on `couchbase-operator` side.