### PR TITLE
DOC-13151 fix zombie 3.x docs issue

### DIFF
--- a/etc/nginx/snippets/rewrites.conf
+++ b/etc/nginx/snippets/rewrites.conf
@@ -215,3 +215,27 @@ location ^~ /sdk-api/couchbase-transactions-java/ { rewrite ^/sdk-api/(couchbase
 location ^~ /sdk-api/couchbase-transactions-cxx/ { rewrite ^/sdk-api/(couchbase-transactions-cxx)/(.*)$ /sdk-api/$1-$current_version_txns_cxx_api/$2 last; }
 location ^~ /sdk-api/couchbase-transactions-dotnet/ { rewrite ^/sdk-api/(couchbase-transactions-dotnet)/(.*)$ /sdk-api/$1-$current_version_txns_dotnet_api/$2 last; }
 # location ^~ /sdk-api/couchbase-agent-catalog/ { rewrite ^/sdk-api/(couchbase-agent-catalog)/(.*)$ /sdk-api/$1-$current_version_sdk_python_ai_api/$2 last; }
+
+# bad admin/admin/ links that went variously to developer.couchbase.com or 200 of stale content
+
+location ^~ /admin/admin/ {
+    # first rewrite pages that have no known candidate to the intro page
+    rewrite ^/admin/admin/enterprise-edition.html           /admin/admin/Couchbase-intro.html;
+    rewrite ^/admin/admin/Install/upgrade-xdcr.html         /admin/admin/Couchbase-intro.html;
+    rewrite ^/admin/admin/Misc/Trbl-wrongdocs.html          /admin/admin/Couchbase-intro.html;
+    rewrite ^/admin/admin/REST/design-docs-rest-api.html    /admin/admin/Couchbase-intro.html;
+    rewrite ^/admin/admin/REST/rest-bucket-get-config.html  /admin/admin/Couchbase-intro.html;
+
+    # then files that have a candidate for redirection
+    rewrite ^/admin/admin/CLI/cli-xdcr-pause-resume.html       /admin/admin/CLI/CBcli/cbcli-xdcr-pause-resume.html;
+    rewrite ^/admin/admin/CLI/cli-failover-graceful.html       /admin/admin/Concepts/graceful-failover.html;
+    rewrite ^/admin/admin/CLI/cbcollect-cluster-wide-info.html /admin/admin/CLI/cbcollect_info_tool.html;
+    rewrite ^/admin/admin/Concepts/security-admin-access.html  /admin/admin/security/security-admin-access.html;
+    rewrite ^/admin/admin/Concepts/security-client-ssl.html    /admin/admin/security/security-client-ssl.html;
+    rewrite ^/admin/admin/Concepts/security-intro.html         /admin/admin/security/security-intro.html;
+    rewrite ^/admin/admin/Misc/security-admin-access.html      /admin/admin/security/security-admin-access.html;
+    rewrite ^/admin/admin/Misc/security-client-ssl.html        /admin/admin/security/security-client-ssl.html;
+
+    # final redirect to archives
+    rewrite ^/admin/(.*)$ $scheme://docs-archive.couchbase.com/docs-3x/$1 permanent;
+}

--- a/etc/nginx/snippets/rewrites.conf
+++ b/etc/nginx/snippets/rewrites.conf
@@ -217,16 +217,12 @@ location ^~ /sdk-api/couchbase-transactions-dotnet/ { rewrite ^/sdk-api/(couchba
 # location ^~ /sdk-api/couchbase-agent-catalog/ { rewrite ^/sdk-api/(couchbase-agent-catalog)/(.*)$ /sdk-api/$1-$current_version_sdk_python_ai_api/$2 last; }
 
 # bad admin/admin/ links that went variously to developer.couchbase.com or 200 of stale content
-
 location ^~ /admin/admin/ {
-    # first rewrite pages that have no known candidate to the intro page
-    rewrite ^/admin/admin/enterprise-edition.html           /admin/admin/Couchbase-intro.html;
-    rewrite ^/admin/admin/Install/upgrade-xdcr.html         /admin/admin/Couchbase-intro.html;
-    rewrite ^/admin/admin/Misc/Trbl-wrongdocs.html          /admin/admin/Couchbase-intro.html;
-    rewrite ^/admin/admin/REST/design-docs-rest-api.html    /admin/admin/Couchbase-intro.html;
-    rewrite ^/admin/admin/REST/rest-bucket-get-config.html  /admin/admin/Couchbase-intro.html;
-
-    # then files that have a candidate for redirection
+    rewrite ^/admin/admin/enterprise-edition.html              /admin/admin/editions.html;
+    rewrite ^/admin/admin/Install/upgrade-xdcr.html            /admin/admin/XDCR/xdcr-intro.html;
+    rewrite ^/admin/admin/Misc/Trbl-wrongdocs.html             /admin/admin/Misc/Trbl-intro.html;
+    rewrite ^/admin/admin/REST/design-docs-rest-api.html       /admin/admin/REST/rest-views-intro.html;
+    rewrite ^/admin/admin/REST/rest-bucket-get-config.html     /admin/admin/REST/rest-bucket-intro.html;
     rewrite ^/admin/admin/CLI/cli-xdcr-pause-resume.html       /admin/admin/CLI/CBcli/cbcli-xdcr-pause-resume.html;
     rewrite ^/admin/admin/CLI/cli-failover-graceful.html       /admin/admin/Concepts/graceful-failover.html;
     rewrite ^/admin/admin/CLI/cbcollect-cluster-wide-info.html /admin/admin/CLI/cbcollect_info_tool.html;


### PR DESCRIPTION
**Context:**

1) @malarky noted that pages like

 BAD https://docs.couchbase.com/admin/admin/enterprise-edition.html

still exist and are indexed by Google.

2) most recent builds of those docs were replaced with an AWS S3 redirect file that would take you to the DA site, e.g.

 404 https://developer.couchbase.com/documentation/server/3.x/admin/pdfs.html

3) ... those links are now unmaintained 404

4) But there are x13 files that were *moved or deleted* and therefore not replaced with those redirection links.
Those remain as **zombie* 200 files with bad content under /admin/admin

5) we have in the meantime restored our 3.x archive docs:

 GOOD https://docs-archive.couchbase.com/docs-3x/admin/Couchbase-intro.html

**Solution:**

Step 1: this commit adds nginx rewrites to:
* rewrite zombie 200 files without a candidate location to the archive link above
* rewrite zombie 200 files that have a good candidate page to a specific page under that tree
* rewrite everything else to within that tree under the same path

Step 2: once tested, we can expunge these unused files from the /admin/admin/ path in the main bucket.

**NOTE ON Testing**

Er, don't currently have a good way to do this, so propose 🤠 (deploy -> test -> rollback).
Happy to put work into improving that if worthwhile, or to schedule this change at the least inconvenient time if not!