### PR TITLE
DOC-13225 override preview config with flag

### DIFF
--- a/lib/preview.js
+++ b/lib/preview.js
@@ -18,6 +18,7 @@ module.exports.register = function () {
     const args = {
         repo: process.env.PREVIEW_REPO,
         branch: process.env.PREVIEW_BRANCH || 'HEAD',
+        config: process.env.PREVIEW_CONFIG || process.env.PREVIEW_BRANCH || 'HEAD',
         remote: process.env.PREVIEW_REMOTE ? true : false,
         repoPath: ((process.env.REPO_PATH || '..')
             .split(':')
@@ -79,9 +80,9 @@ module.exports.register = function () {
     const antoraYml = readYaml(antoraYmlPath)
 
     const previewConfig =
-        readYaml(`${basePath}/preview/${args.branch}.yml`) ||
+        readYaml(`${basePath}/preview/${args.config}.yml`) ||
         readYaml(`${basePath}/preview/HEAD.yml`) ||
-        antoraYml.ext?.preview?.[args.branch] || 
+        antoraYml.ext?.preview?.[args.config] || 
         antoraYml.ext?.preview?.HEAD || {}
 
     const desiredSources = deepmerge({mergeArray: overrideArray})

--- a/scripts/preview
+++ b/scripts/preview
@@ -76,39 +76,6 @@ POSITIONAL_ARGS=()
 REMOTE=""
 INIT=""
 
-while [[ $# -gt 0 ]]; do
-  case $1 in
-    -h|--help)
-      help
-      exit 0
-      ;;
-    -r|--remote)
-      REMOTE="true"
-      shift # past argument
-      ;;
-    --init)
-      INIT=true
-      shift
-      ;;
-    -*|--*)
-      echo "Unknown option $1"
-      exit 1
-      ;;
-    *)
-      POSITIONAL_ARGS+=("$1") # save positional arg
-      shift # past argument
-      ;;
-  esac
-done
-
-if [ -n "$INIT" ]; then
-    echo "Linking 'preview' command (you may need to enter your password)"
-    set -x
-    sudo ln -sf $(realpath $0) /usr/local/bin/preview
-    which preview
-    exit 0
-fi
-
 # define utility function
 upfind () {
     WHAT=$1
@@ -131,6 +98,45 @@ TOPLEVEL=$(git rev-parse --show-toplevel)
 export PREVIEW_REPO=$(basename $TOPLEVEL)
 export PREVIEW_BRANCH=$(git branch --show-current)
 export PREVIEW_START_PATH=.${ANTORA#$TOPLEVEL}
+export PREVIEW_CONFIG=$PREVIEW_BRANCH
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -h|--help)
+      help
+      exit 0
+      ;;
+    -r|--remote)
+      REMOTE="true"
+      shift # past argument
+      ;;
+    --init)
+      INIT=true
+      shift
+      ;;
+    -c|--config)
+      shift
+      PREVIEW_CONFIG=$1
+      shift
+      ;;
+    -*|--*)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+    *)
+      POSITIONAL_ARGS+=("$1") # save positional arg
+      shift # past argument
+      ;;
+  esac
+done
+
+if [ -n "$INIT" ]; then
+    echo "Linking 'preview' command (you may need to enter your password)"
+    set -x
+    sudo ln -sf $(realpath $0) /usr/local/bin/preview
+    which preview
+    exit 0
+fi
 
 if [ -z "$REMOTE" ]; then
     export PREVIEW_OVERRIDE=${PREVIEW_OVERRIDE:-antora-playbook.preview.local.yml}
@@ -158,6 +164,7 @@ assert() {
 if [ -n "$REMOTE" ]; then
     assert "$(git status -s -uno)" '' 'You have uncommitted changes.'
     assert "$(git push --dry-run 2>&1)" 'Everything up-to-date' 'You have unpushed changes.'
+    assert "$PREVIEW_BRANCH" "$PREVIEW_CONFIG" "Remote preview doesn't support custom --config, will be ignored"
 
     WORKFLOW=preview-deploy.yml
     UUID=$(uuidgen)


### PR DESCRIPTION
(Only for local previews - could add to remote, but I do like the current case where all previews are easily mapped to the config that created them, does make it easier to manage)

@simon-dew test with

```
# in docs-site
git fetch
git checkout DOC-13225-preview-config

# in your repo
cp preview/HEAD.yml preview/SIMON.yml
# edit config as required

preview -c SIMON
```