### PR TITLE
Fix for https://github.com/RayOffiah/asciidoctor-external-callout-js/issues/6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fastify/deepmerge": "^2.0.0",
         "antora": "~3.1",
         "array.prototype.groupby": "^1.1.0",
-        "asciidoctor-external-callout": "~1.2.0",
+        "asciidoctor-external-callout": "~1.2.2",
         "asciidoctor-kroki": "0.18.1",
         "gulp": "~4.0",
         "gulp-connect": "~5.7",
@@ -939,9 +939,9 @@
       }
     },
     "node_modules/asciidoctor-external-callout": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/asciidoctor-external-callout/-/asciidoctor-external-callout-1.2.1.tgz",
-      "integrity": "sha512-72AFE5771oYcGf72dViPYyR9Ar0/nLnZ+xRTxkoXxrxmnItPUkNXbPwAsa61ZPixG5enwrkRX1b6DOjnv+vy3A==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/asciidoctor-external-callout/-/asciidoctor-external-callout-1.2.2.tgz",
+      "integrity": "sha512-IcqrPDGQn2YkpySlpr+4qniOeu5mMwH5Ocsqh772OD7syQreoMqZYLdC6ilJvLUw37ckUXkTLRwY5rqdVTpowQ==",
       "dependencies": {
         "@asciidoctor/core": "^2.2.6"
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@fastify/deepmerge": "^2.0.0",
     "antora": "~3.1",
     "array.prototype.groupby": "^1.1.0",
-    "asciidoctor-external-callout": "~1.2.0",
+    "asciidoctor-external-callout": "~1.2.2",
     "asciidoctor-kroki": "0.18.1",
     "gulp": "~4.0",
     "gulp-connect": "~5.7",


### PR DESCRIPTION
Fixes an issue whereby the asciidoctor external callout extension was adding callouts globally, when it should have been adding them for the first match only.