### PR TITLE
Add NGINX redirect rules for erroneous API pages and test configuration

### DIFF
--- a/etc/nginx/snippets/rewrites.conf
+++ b/etc/nginx/snippets/rewrites.conf
@@ -242,3 +242,14 @@ location ^~ /admin/admin/ {
     # final redirect to archives
     rewrite ^/admin/(.*)$ $scheme://docs-archive.couchbase.com/docs-3x/$1 permanent;
 }
+
+# Send some of the erroneous API pages to their correct pages
+
+location ~* ^/mobile/([^/]+)/([^/]+)/Enumerations\.html$ {
+    return 301 /mobile/$1/$2/Enums.html;
+}
+
+location ~* ^/mobile/([^/]+)/([^/]+)/Structures\.html$ {
+    return 301 /mobile/$1/$2/Structs.html;
+}
+

--- a/etc/nginx/snippets/rewrites.conf
+++ b/etc/nginx/snippets/rewrites.conf
@@ -244,12 +244,8 @@ location ^~ /admin/admin/ {
 }
 
 # Send some of the erroneous API pages to their correct pages
-
-location ~* ^/mobile/([^/]+)/([^/]+)/Enumerations\.html$ {
-    return 301 /mobile/$1/$2/Enums.html;
-}
-
-location ~* ^/mobile/([^/]+)/([^/]+)/Structures\.html$ {
-    return 301 /mobile/$1/$2/Structs.html;
+location ^~ /mobile/ {
+    rewrite ^/mobile/([^/]+)/([^/]+)/Enumerations.html$ /mobile/$1/$2/Enums.html redirect; 
+    rewrite ^/mobile/([^/]+)/([^/]+)/Structures.html$ /mobile/$1/$2/Structs.html redirect; 
 }
 


### PR DESCRIPTION
Added rules to trap and redirect the pages for API `Enumerations` and `Structures`.