### PR TITLE
DOC-13291: Sync Gateway 3.3 Docs

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -149,7 +149,7 @@ content:
   - url: https://github.com/couchbaselabs/docs-couchbase-lite
     branches: [release/3.2, release/3.1, release/3.0, release/2.8]
   - url: https://github.com/couchbaselabs/docs-sync-gateway
-    branches: [release/3.2, release/3.1, release/3.0, release/2.8]
+    branches: [release/3.3, release/3.2, release/3.1, release/3.0, release/2.8]
   - url: https://github.com/couchbaselabs/docs-couchbase-lite-edge-server
     branches: [release/1.0]
   - url: https://github.com/couchbase/edge-server


### PR DESCRIPTION
Docs issue: [DOC-13291](https://jira.issues.couchbase.com/browse/DOC-13291)

This PR publishes the Sync Gateway 3.3 documentation.

Staging docs:
- [New In 3.3 › Release 3.3.0 (June 2025)](https://docs-staging.couchbase.com/sync-gateway/current/whatsnew.html#release-3-3-0-june-2025)
- [Sync Gateway Admin REST API Reference](https://docs-staging.couchbase.com/sync-gateway/current/rest_api_admin.html)
- [SG Collect Info](https://docs-staging.couchbase.com/sync-gateway/current/sgcollect-info.html)
- [Indexes](https://docs-staging.couchbase.com/sync-gateway/current/indexing.html)
- [Partitioned Indexes](https://docs-staging.couchbase.com/sync-gateway/current/index-partitions.html)
- [Release Notes](https://docs-staging.couchbase.com/sync-gateway/current/release-notes.html)
- [Supported Environments](https://docs-staging.couchbase.com/sync-gateway/current/supported-environments.html)
- [Compatibility](https://docs-staging.couchbase.com/sync-gateway/current/compatibility.html)

Other changes include: 

- Updating the Redocly REST API pages
- Deprecating `num_index_replicas` in favor of `index.num_replicas`
- Deprecating `enable_shared_bucket_access`

[DOC-13291]: https://couchbasecloud.atlassian.net/browse/DOC-13291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ