### PR TITLE
DOC-13521 calculate staging playbook

### DIFF
--- a/antora-playbook-staging.diff.yml
+++ b/antora-playbook-staging.diff.yml
@@ -1,0 +1,51 @@
+antora:
+  extensions:
+  - ./lib/report-tree.js
+
+site:
+  title: Couchbase Docs Staging
+  url: https://docs-staging.couchbase.com
+  start_page: home::index.adoc
+  robots: |
+    User-agent: *
+    Disallow: /
+
+    User-agent: Algolia Crawler
+    Allow: /
+  keys:
+    google_analytics: ~
+
+content:
+
+  $select:
+    - '**' # everything
+    # see https://github.com/micromatch/picomatch for full details
+    # e.g.
+    # - '**/*sdk*' # add all repos matching *sdk*
+
+  # start off with first 3 branches
+  $prune: 3
+
+  sources:
+  - url: https://github.com/couchbaselabs/cb-swagger
+    branches: [capella] # ensure added as well as most recent release/* branches
+
+  - url: https://github.com/couchbaselabs/docs-devex
+    branches: [capella] # ensure added as well as most recent release/* branches
+
+  - url: https://github.com/couchbase/docs-operator
+    branches: [release/2.8.1]
+    # release/2.8.1 is set to version `2.9` so should not clash with release/2.8
+
+  - url: https://github.com/couchbaselabs/cbmultimanager
+    branches:
+      $replace: [master]
+
+  - url: https://github.com/couchbase/docs-sdk-kotlin
+    branches: 
+      # 'release/3.9' instead of 'temp/3.9'
+      $replace: [release/3.9, temp/1.5, temp/1.4, temp/1.3, release/1.2]
+
+# ui:
+  # bundle:
+    # url: https://github.com/couchbase/docs-ui/releases/download/prod-216/ui-bundle.zip

--- a/antora-playbook-staging.yml
+++ b/antora-playbook-staging.yml
@@ -1,13 +1,66 @@
-# npx antora --clean --fetch antora-playbook.yml
-# or
-# npx antora antora-playbook.yml
+######
+# WARNING: DO NOT EDIT BY HAND
+# (it will get overwritten)
+#
+# Instead
+#
+#  * edit antora-playbook-staging.diff.yml with just the *differences* from the main playbook
+#  * run: /Users/hakimcassimally/couchbase/docs-site/scripts/patch-cutdown-playbook antora-playbook-staging 
+
+git:
+  ensure_git_suffix: false
+  fetch_concurrency: 1
+urls:
+  latest_version_segment_strategy: redirect:to
+  latest_version_segment: current
+asciidoc:
+  attributes:
+    site-navigation-data-path: _/js/site-navigation-data.js
+    enable-cmos: ""
+    max-include-depth: 10
+    page-partial: false
+    experimental: ""
+    idprefix: "@"
+    idseparator: -@
+    tabs: tabs
+    tabs-sync-option: ""
+    toc: null
+    page-toclevels: 1@
+    page-rank: 50@
+    xrefstyle: short
+    enterprise: https://www.couchbase.com/products/editions[ENTERPRISE EDITION]
+    community: https://www.couchbase.com/products/editions[COMMUNITY EDITION]
+    sqlpp: SQL++
+    sqlppc: SQL++ for Capella Analytics
+    sqlppea: SQL++ for Enterprise Analytics
+    sqlpp_url: https://www.couchbase.com/products/n1ql
+    cbpp: Couchbase++
+    kroki-server-url: http://3.91.133.254:9500
+    kroki-fetch-diagram: true
+  extensions:
+    - ./lib/source-url-include-processor.js
+    - ./lib/json-config-ui-block-macro.js
+    - ./lib/inline-man-macro.js
+    - ./lib/multirow-table-head-tree-processor.js
+    - ./lib/swagger-ui-block-macro.js
+    - ./lib/markdown-block.js
+    - ./lib/template-block.js
+    - asciidoctor-kroki
+    - asciidoctor-external-callout
+    - "@asciidoctor/tabs"
+ui:
+  bundle:
+    url: https://github.com/couchbase/docs-ui/releases/download/prod-216/ui-bundle.zip
+output:
+  dir: ./public
+runtime:
+  fetch: true
 antora:
   extensions:
-  - '@antora/site-generator-ms'
-  - ./lib/embargo.js
-  - "@antora/collector-extension"
-  - ./lib/antora-component-version-rank.js
-  - ./lib/report-tree.js
+    - "@antora/site-generator-ms"
+    - ./lib/embargo.js
+    - ./lib/antora-component-version-rank.js
+    - ./lib/report-tree.js
 site:
   title: Couchbase Docs Staging
   url: https://docs-staging.couchbase.com
@@ -19,13 +72,13 @@ site:
     User-agent: Algolia Crawler
     Allow: /
   keys:
-    nav_groups: |
+    nav_groups: >
       [
-        { "title": "Server", "startPage": "home::server.adoc", "components": ["server"] },
+        { "title": "Server", "startPage": "home::server.adoc", "components": ["server", "enterprise-analytics"] },
         { "title": "Mobile / Edge", "startPage": "home::mobile.adoc", "components": ["couchbase-lite", "sync-gateway", "couchbase-edge-server"] },
-        { "title": "Capella", "startPage": "home::cloud.adoc", "components": ["cloud", "columnar"] },
-        { "title": "Cloud-Native", "startPage": "cloud-native-database::index.adoc", "components": ["cloud-native-database"] },
-        { "title": "Autonomous Operator", "components": ["operator"] },
+        { "title": "Capella", "startPage": "home::cloud.adoc", "components": ["cloud", "analytics"] },
+        { "title": "Cloud-Native", "components": ["cloud-native-database"] },
+        { "title": "Kubernetes Operator", "startPage": "operator::overview.adoc", "components": ["operator"] },
         { "title": "CMOS", "components": ["cmos"] },
         { "title": "Develop", "startPage": "home::developer.adoc", 
             "subGroups": [
@@ -41,207 +94,266 @@ site:
               }
             ]
           },
+        { "title": "Tutorials", "startPage": "tutorials::index.adoc", "components": ["tutorials"] },
         { "title": "Contribute", "components": ["home", "styleguide", "ui-ux", "pendo"] }
       ]
-git:
-  ensure_git_suffix: false
-  fetch_concurrency: 1
-urls:
-  latest_version_segment_strategy: redirect:to
-  latest_version_segment: current
+    google_analytics: null
 content:
   branches: master
-  # NOTE the git@ segment in the URL indicates which repositories are private
-  ## The above has a bug when upgrading to Antora 3.1. Original sources commented
-  ## out and replaced with a non git@ prefix. To revert if it causes issues
   sources:
-  - url: .
-    branches: HEAD
-    start_path: home
-  - url: https://github.com/couchbaselabs/docs-style-guide
-    branches: main
-    start_paths: [styleguide, ui-ux, pendo]
-  - url: https://github.com/couchbaselabs/docs-devex
-    branches: [release/7.6, release/7.2, capella]
-  - url: https://github.com/couchbaselabs/cb-swagger
-    branches: [release/7.6, release/7.2, release/7.1, release/7.0, capella]
-    start_path: docs
-  - url: https://github.com/couchbasecloud/couchbase-cloud
-    branches: [main]
-    start_paths: [docs/public, docs/columnar]
-  - url: https://github.com/couchbase/docs-capella
-    branches: [main]
-
-  - url: https://github.com/couchbaselabs/docs-columnar
-    branches:
-        - main                      # `analytics` component (Capella Analytics)
-        - legacy-columnar-component # `columnar` dummy component for sake of :page-aliases:
-      # see under Server section below for enterprise-analytics and legacy analytics
-
-  # Operator unbundling test:
-  - url: https://github.com/couchbase/couchbase-operator
-    branches: [2.8.x, 2.7.x, 2.6.x, 2.5.x, 2.4.x]
-    start_path: docs/user
-  - url: https://github.com/couchbase/docs-operator
-    branches: [release/2.8.1, release/2.8, release/2.7, release/2.6, release/2.5, release/2.4]
-    # release/2.8.1 is set to version `2.9` so should not clash with release/2.8
-
-  - url: https://github.com/couchbaselabs/observability
-    branches: [main]
-    start_path: docs
-  - url: https://github.com/couchbaselabs/cbmultimanager
-    branches: [master]
-    start_path: docs
-  - url: https://github.com/couchbase/docs-elastic-search
-    branches: [main]
-  - url: https://github.com/couchbase/docs-kafka
-    branches: [release/4.2, release/4.3]
-  - url: https://github.com/couchbase/docs-spark
-    branches: [release/3.5, release/3.3]
-  - url: https://github.com/couchbase/docs-tableau
-    branches: [release/1.1, release/1.0]
-  - url: https://github.com/couchbase/docs-connectors-power-bi
-    branches: [main]
-  - url: https://github.com/couchbase/docs-connectors-superset.git
-    branches: [release/1.0]
-  - url: https://github.com/couchbase/docs-connectors-talend
-
-  - url: https://github.com/couchbaselabs/docs-enterprise-analytics
-    branches: [release/2.0]
-  - url: https://github.com/couchbase/docs-analytics
-    branches: [release/7.6, release/7.2, release/7.1, release/7.0]
-  - url: https://github.com/couchbase/couchbase-cli
-    branches: [trinity, neo, 7.1.x-docs, cheshire-cat]
-    start_path: docs
-  - url: https://github.com/couchbase/backup
-    branches: [trinity, neo, 7.1.x-docs, cheshire-cat]
-    start_path: docs
-  # NOTE docs-server is currently after other server repos so nav key wins
-  - url: https://github.com/couchbase/docs-server
-    branches: [release/7.6, release/7.2, release/7.1, release/7.0]
-  - url: https://github.com/couchbase/docs-sdk-common
-    branches: [release/8.0, release/7.7, release/7.6.6, release/7.6.2, release/7.6, temp/7.5, release/7.2, release/7.1.2, release/7.1, release/7.0, release/6.6, release/6.5]
-  - url: https://github.com/couchbase/docs-sdk-c
-    branches: [release/3.3]
-  - url: https://github.com/couchbase/docs-sdk-cxx
-    branches: [release/1.2, release/1.1, release/1.0]
-  - url: https://github.com/couchbase/docs-sdk-dotnet
-    branches: [temp/3.8, temp/3.7, temp/3.6, release/3.5, release/3.4]
-  - url: https://github.com/couchbase/docs-efcore
-    branches: [release/1.0]
-  - url: https://github.com/couchbase/docs-sdk-go
-    branches: [temp/2.10, temp/2.9, temp/2.8, release/2.7, release/2.6]
-  - url: https://github.com/couchbase/docs-sdk-java
-    branches: [release/3.9, release/3.8, temp/3.7, temp/3.6, release/3.5, release/3.4]
-  - url: https://github.com/couchbase/docs-quarkus-extension
-    branches: [release/1.1, release/1.0]
-  - url: https://github.com/couchbase/docs-sdk-kotlin
-    branches: [release/3.9, temp/1.5, temp/1.4, temp/1.3, release/1.2, release/1.1]
-  - url: https://github.com/couchbase/docs-sdk-nodejs
-    branches: [temp/4.5, temp/4.4, temp/4.3, release/4.2]
-  - url: https://github.com/couchbase/docs-sdk-php
-    branches: [temp/4.3, temp/4.2, release/4.1]
-  - url: https://github.com/couchbase/docs-sdk-python
-    branches: [temp/4.4, temp/4.3, temp/4.2, release/4.1]
-  - url: https://github.com/couchbase/docs-sdk-ruby
-    branches: [temp/3.6, temp/3.5, release/3.4]
-  - url: https://github.com/couchbase/docs-sdk-scala
-    branches: [release/3.9, release/1.8, release/1.7, temp/1.6, release/1.5, release/1.4]
-  - url: https://github.com/couchbase/docs-sdk-extensions
-    branches: [main]
-    # Analytics dev
-  - url: https://github.com/couchbase/docs-columnar-sdk-common
-    branches: [release/1.0]
-  - url: https://github.com/couchbase/docs-analytics-sdk-common
-    branches: [release/1.0]
-  - url: https://github.com/couchbase/docs-analytics-sdk-go
-    branches: [release/1.0]
-  - url: https://github.com/couchbase/docs-analytics-sdk-java
-    branches: [release/1.0]
-  - url: https://github.com/couchbase/docs-analytics-sdk-nodejs
-    branches: [release/1.0]
-  - url: https://github.com/couchbase/docs-analytics-sdk-python
-    branches: [release/1.0]
-  - url: https://github.com/couchbase/docs-columnar-sdk-go
-    branches: [release/1.0]
-  - url: https://github.com/couchbase/docs-columnar-sdk-java
-    branches: [release/1.0]
-  - url: https://github.com/couchbase/docs-columnar-sdk-nodejs
-    branches: [release/1.0]
-  - url: https://github.com/couchbase/docs-columnar-sdk-python
-    branches: [release/1.0]
-    # Mobile Docs Pages
-  - url: https://github.com/couchbase/docs-mobile
-    branches: [release/3.1, release/2.8]
-  - url: https://github.com/couchbaselabs/docs-couchbase-lite
-    branches: [release/3.3, release/3.2, release/3.1, release/3.0, release/2.8]
-  - url: https://github.com/couchbaselabs/docs-sync-gateway
-    branches: [release/3.3, release/3.2, release/3.1, release/3.0, release/2.8]
-  - url: https://github.com/couchbaselabs/docs-couchbase-lite-edge-server
-    branches: [release/1.0]
-  - url: https://github.com/couchbase/edge-server
-    branches: [main]
-    start_path: docs
-  - url: https://github.com/couchbase/docs-cloud-native
-    branches: [cloud-native-2.2]
-  - url: https://github.com/couchbaselabs/mobile-travel-sample
-    branches: [master]
-    start_path: content
-  - url: https://github.com/couchbaselabs/mobile-training-todo
-    branches: tutorials
-    start_path: content
-  - url: https://github.com/couchbaselabs/UniversityLister-Android
-    start_path: content
-  - url: https://github.com/couchbaselabs/userprofile-couchbase-mobile
-    branches: [standalone, query, sync, backgroundfetch]
-    start_path: content
-  - url: https://github.com/couchbaselabs/userprofile-couchbase-mobile-xamarin
-    branches: [standalone, query, sync]
-    start_path: content
-  - url: https://github.com/couchbaselabs/userprofile-couchbase-mobile-android
-    branches: [standalone, query, sync]
-    start_path: content
-  - url: https://github.com/couchbaselabs/couchbase-lite-peer-to-peer-sync-examples
-    branches: [master]
-    start_path: content
-asciidoc:
-  attributes:
-    site-navigation-data-path: _/js/site-navigation-data.js
-    enable-cmos: ''
-    max-include-depth: 10
-    page-partial: false
-    experimental: ''
-    idprefix: '@'
-    idseparator: '-@'
-    tabs: tabs
-    tabs-sync-option: ''
-    toc: ~
-    page-toclevels: 1@
-    page-rank: 50@
-    xrefstyle: short
-    enterprise: https://www.couchbase.com/products/editions[ENTERPRISE EDITION]
-    community: https://www.couchbase.com/products/editions[COMMUNITY EDITION]
-    sqlpp: SQL++
-    sqlppc: SQL++ for Capella columnar
-    sqlpp_url: https://www.couchbase.com/products/n1ql
-    cbpp: Couchbase++
-    kroki-server-url: http://3.91.133.254:9500
-    kroki-fetch-diagram: true
-  extensions:
-  - ./lib/source-url-include-processor.js
-  - ./lib/json-config-ui-block-macro.js
-  - ./lib/inline-man-macro.js
-  - ./lib/multirow-table-head-tree-processor.js
-  - ./lib/swagger-ui-block-macro.js
-  - ./lib/markdown-block.js
-  - ./lib/template-block.js
-  - asciidoctor-kroki
-  - asciidoctor-external-callout
-  - '@asciidoctor/tabs'
-ui:
-  bundle:
-    url: https://github.com/couchbase/docs-ui/releases/download/prod-216/ui-bundle.zip
-output:
-  dir: ./public
-runtime:
-  fetch: true
+    - url: https://github.com/couchbaselabs/docs-style-guide
+      branches: mai
+      start_paths:
+        - styleguide
+        - ui-ux
+        - pendo
+    - url: https://github.com/couchbaselabs/docs-devex
+      branches:
+        - capella
+        - release/7.6
+        - release/7.2
+    - url: https://github.com/couchbaselabs/cb-swagger
+      start_path: docs
+      branches:
+        - capella
+        - release/7.6
+        - release/7.2
+        - release/7.1
+    - url: https://github.com/couchbasecloud/couchbase-cloud
+      branches:
+        - main
+      start_paths:
+        - docs/public
+        - docs/columnar
+    - url: https://github.com/couchbase/docs-capella
+      branches:
+        - main
+    - url: https://github.com/couchbaselabs/docs-columnar
+      branches:
+        - main
+        - legacy-columnar-component
+    - url: https://github.com/couchbase/couchbase-operator
+      branches:
+        - 2.8.x
+        - 2.7.x
+        - 2.6.x
+      start_path: docs/user
+    - url: https://github.com/couchbase/docs-operator
+      branches:
+        - release/2.8.1
+        - release/2.8
+        - release/2.7
+        - release/2.6
+    - url: https://github.com/couchbaselabs/observability
+      branches:
+        - 0.2.x
+      start_path: docs
+    - url: https://github.com/couchbaselabs/cbmultimanager
+      start_path: docs
+      branches:
+        - master
+    - url: https://github.com/couchbase/docs-cloud-native
+      branches:
+        - cloud-native-2.2
+    - url: https://github.com/couchbase/docs-elastic-search
+      branches:
+        - main
+    - url: https://github.com/couchbase/docs-kafka
+      branches:
+        - release/4.3
+        - release/4.2
+    - url: https://github.com/couchbase/docs-spark
+      branches:
+        - release/3.5
+        - release/3.3
+    - url: https://github.com/couchbase/docs-tableau
+      branches:
+        - release/1.1
+        - release/1.0
+    - url: https://github.com/couchbase/docs-connectors-power-bi
+      branches:
+        - main
+    - url: https://github.com/couchbase/docs-connectors-superset.git
+      branches:
+        - release/1.0
+    - url: https://github.com/couchbase/docs-connectors-talend
+      branches:
+        - master
+    - url: https://github.com/couchbaselabs/docs-enterprise-analytics
+      branches:
+        - release/2.0
+    - url: https://github.com/couchbase/docs-analytics
+      branches:
+        - release/7.6
+        - release/7.2
+        - release/7.1
+    - url: https://github.com/couchbase/couchbase-cli
+      branches:
+        - trinity
+        - neo
+        - 7.1.x-docs
+      start_path: docs
+    - url: https://github.com/couchbase/backup
+      branches:
+        - trinity
+        - neo
+        - 7.1.x-docs
+      start_path: docs
+    - url: https://github.com/couchbase/docs-server
+      branches:
+        - release/7.6
+        - release/7.2
+        - release/7.1
+    - url: https://github.com/couchbase/docs-sdk-common
+      branches:
+        - release/8.0
+        - release/7.7
+        - release/7.6.6
+    - url: https://github.com/couchbase/docs-sdk-c
+      branches:
+        - release/3.3
+    - url: https://github.com/couchbase/docs-sdk-cxx
+      branches:
+        - release/1.1
+        - release/1.0
+    - url: https://github.com/couchbase/docs-sdk-dotnet
+      branches:
+        - temp/3.8
+        - temp/3.7
+        - temp/3.6
+    - url: https://github.com/couchbase/docs-efcore
+      branches:
+        - release/1.0
+    - url: https://github.com/couchbase/docs-sdk-go
+      branches:
+        - temp/2.11
+        - temp/2.10
+        - temp/2.9
+    - url: https://github.com/couchbase/docs-sdk-java
+      branches:
+        - release/3.9
+        - release/3.8
+        - temp/3.7
+    - url: https://github.com/couchbase/docs-quarkus-extension
+      branches:
+        - release/1.1
+        - release/1.0
+    - url: https://github.com/couchbase/docs-sdk-kotlin
+      branches:
+        - release/3.9
+        - temp/1.5
+        - temp/1.4
+        - temp/1.3
+        - release/1.2
+    - url: https://github.com/couchbase/docs-sdk-scala
+      branches:
+        - release/3.9
+        - release/1.8
+        - release/1.7
+    - url: https://github.com/couchbase/docs-sdk-nodejs
+      branches:
+        - temp/4.5
+        - temp/4.4
+        - temp/4.3
+    - url: https://github.com/couchbase/docs-sdk-php
+      branches:
+        - temp/4.3
+        - temp/4.2
+        - release/4.1
+    - url: https://github.com/couchbase/docs-sdk-python
+      branches:
+        - temp/4.4
+        - temp/4.3
+        - temp/4.2
+    - url: https://github.com/couchbase/docs-sdk-ruby
+      branches:
+        - temp/3.6
+        - temp/3.5
+        - release/3.4
+    - url: https://github.com/couchbase/docs-sdk-extensions
+      branches:
+        - main
+    - url: https://github.com/couchbase/docs-columnar-sdk-common
+      branches:
+        - release/1.0
+    - url: https://github.com/couchbase/docs-columnar-sdk-go
+      branches:
+        - release/1.0
+    - url: https://github.com/couchbase/docs-columnar-sdk-java
+      branches:
+        - release/1.0
+    - url: https://github.com/couchbase/docs-columnar-sdk-nodejs
+      branches:
+        - release/1.0
+    - url: https://github.com/couchbase/docs-columnar-sdk-python
+      branches:
+        - release/1.0
+    - url: https://github.com/couchbase/docs-analytics-sdk-common
+      branches:
+        - release/1.0
+    - url: https://github.com/couchbase/docs-analytics-sdk-go
+      branches:
+        - release/1.0
+    - url: https://github.com/couchbase/docs-analytics-sdk-java
+      branches:
+        - release/1.0
+    - url: https://github.com/couchbase/docs-analytics-sdk-nodejs
+      branches:
+        - release/1.0
+    - url: https://github.com/couchbase/docs-analytics-sdk-python
+      branches:
+        - release/1.0
+    - url: https://github.com/couchbase/docs-mobile
+      branches:
+        - release/3.1
+        - release/2.8
+    - url: https://github.com/couchbaselabs/docs-couchbase-lite
+      branches:
+        - release/3.2
+        - release/3.1
+        - release/3.0
+    - url: https://github.com/couchbaselabs/docs-sync-gateway
+      branches:
+        - release/3.3
+        - release/3.2
+        - release/3.1
+    - url: https://github.com/couchbaselabs/docs-couchbase-lite-edge-server
+      branches:
+        - release/1.0
+    - url: https://github.com/couchbase/edge-server
+      branches:
+        - main
+      start_path: docs
+    - url: https://github.com/couchbaselabs/mobile-travel-sample
+      branches:
+        - master
+      start_path: content
+    - url: https://github.com/couchbaselabs/mobile-training-todo
+      branches: tut
+      start_path: content
+    - url: https://github.com/couchbaselabs/UniversityLister-Android
+      start_path: content
+      branches:
+        - master
+    - url: https://github.com/couchbaselabs/userprofile-couchbase-mobile
+      branches:
+        - standalone
+        - query
+        - sync
+      start_path: content
+    - url: https://github.com/couchbaselabs/userprofile-couchbase-mobile-xamarin
+      branches:
+        - standalone
+        - query
+        - sync
+      start_path: content
+    - url: https://github.com/couchbaselabs/userprofile-couchbase-mobile-android
+      branches:
+        - standalone
+        - query
+        - sync
+      start_path: content
+    - url: https://github.com/couchbaselabs/couchbase-lite-peer-to-peer-sync-examples
+      branches:
+        - master
+      start_path: content

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "gulp-connect": "~5.7",
         "js-yaml": "~4.1",
         "markdown-it": "^13.0.1",
+        "picomatch": "^4.0.3",
         "yaml": "^2.7.0"
       },
       "devDependencies": {
@@ -4252,9 +4253,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "gulp-connect": "~5.7",
     "js-yaml": "~4.1",
     "markdown-it": "^13.0.1",
+    "picomatch": "^4.0.3",
     "yaml": "^2.7.0"
   },
   "devDependencies": {

--- a/scripts/patch-cutdown-playbook
+++ b/scripts/patch-cutdown-playbook
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+'use strict'
+
+const path = require('node:path')
+const yaml = require('yaml')
+const fs = require('node:fs')
+const deepmerge = require('@fastify/deepmerge')
+const picomatch = require('picomatch')
+
+function readYaml (path) {
+  if (fs.existsSync(path)) {
+    return yaml.parse(fs.readFileSync(path).toString())
+  }
+  else {
+    throw new Error(`Could not find ${path}`)
+  }
+}
+
+const [_,script, BASE] = process.argv
+if (! BASE) {
+    throw new Error(`Pass in the basename of the playbook to create, like 'antora-playbook-staging'`)
+}
+
+
+let {content: {sources, ...content},   ...playbook} = readYaml('antora-playbook.yml')
+const {content: {$select, $prune, sources: ds, ...dc}, ...diff} = readYaml(`${BASE}.diff.yml`)
+
+
+function mergeArray(target, source) {
+  if (typeof target != 'object') { target = [target] }
+  if (typeof source != 'object') { source = [source] }
+
+  return Array.from(new Set([...target, ...source]))
+}
+const mergeArrayPrepend = (target, source) => mergeArray(source, target)
+
+let preview = deepmerge({mergeArray: (_) => mergeArray, all: true})(
+  playbook,
+  {content},
+  diff,
+  {content: dc})
+
+if ($select) {
+  const f = picomatch($select)
+  sources = sources.filter((s) => {
+    return f(s.url)})
+}
+
+let sn = Object.groupBy(ds, (s) => s.url)
+
+sources = sources.map(({url, ...s}) => {
+  if ($prune) {
+    s.branches = (s.branches || ['master']).slice(0,$prune)
+  }
+
+  let s2 = sn[url]
+  if (s2) {
+    console.log(url, sn[url])
+    delete sn[url]
+    ;[s2] = s2
+    s = deepmerge({mergeArray: (_) => mergeArrayPrepend})(s, s2)
+
+    /*
+     * if branches: [...] then it'll get merged
+     * BUT... if we defined $replace then we'll clobber with the object instead */
+    s.branches = s.branches.$replace || s.branches
+  }
+
+  return {url, ...s}
+})
+
+for (const s of Object.values(sn).flat()) {
+  if ('$prepend' in s) {
+    delete s.$prepend
+    sources.unshift(s)
+  }
+  else {
+    sources.push(s)
+  }
+}
+
+preview.content.sources = sources
+
+const header = `\######
+# WARNING: DO NOT EDIT BY HAND
+# (it will get overwritten)
+#
+# Instead
+#
+#  * edit ${BASE}.diff.yml with just the *differences* from the main playbook
+#  * run: ${script} ${BASE} \n\n`
+
+fs.writeFileSync(
+  `${BASE}.yml`,
+  header + yaml.stringify(preview),
+  { encoding: 'utf8' })
+


### PR DESCRIPTION
Rationale: as well as the staging playbook, we now have to manage:

* the template preview playbook
* 1+ playbooks for chatbot
* escrow playbook

All of which need to be kept in sync with the main playbook, preserving just important differences.

As the staging playbook is the most high-profile one with likely the most complexity in setting it up, I'm starting with that, to check that we can do this fully enough to support the requirement.

(The preview one is currently supported by the more straight-forward scripts/patch-preview-playbook, but could use the same code.)