### PR TITLE
Update instances of the Columnar naming on the Capella landing page

### DIFF
--- a/home/modules/ROOT/pages/cloud.adoc
+++ b/home/modules/ROOT/pages/cloud.adoc
@@ -15,8 +15,8 @@ include::home::partial$info-banner.adoc[]
 Capella operational is the easiest way to use our Couchbase NoSQL database.
 Get access to SQL-like querying, full-text search, powerful eventing, and connect to mobile and IoT devices at the edge.
 
-Capella columnar is an analytical database (RT-OLAP) for real time apps and operational intelligence.
-Capella columnar is a standalone, cloud-only offering from Couchbase under the Capella family of products.
+Capella Analytics is an analytical database (RT-OLAP) for real time apps and operational intelligence.
+Capella Analytics is a standalone, cloud-only offering from Couchbase under the Capella family of products.
 
 
 [.centered.card-container]
@@ -38,7 +38,7 @@ Get set up with an account and deploy a free tier operational cluster.
 [.card-box]
 === icon:rocket[] Get Started With Capella Analytics
 
-Create your account and follow our tutorial on how to load data into your columnar cluster.
+Create your account and follow our tutorial on how to load data into your Analytics cluster.
 
 * https://cloud.couchbase.com/sign-up[Sign Up^]
 * xref:analytics:intro:intro.adoc[]


### PR DESCRIPTION
Just a few instances of "Columnar" remaining on the Capella landing page that needed cleaning up.