### PR TITLE
Document Editions, Deprecation, and Version Page Labels

### DIFF
--- a/home/modules/contribute/pages/attributes-and-roles.adoc
+++ b/home/modules/contribute/pages/attributes-and-roles.adoc
@@ -1,4 +1,5 @@
 = Attributes and Roles
+:page-toclevels: 3
 
 Use attributes and roles to insert content or CSS styles into your pages. 
 
@@ -102,6 +103,44 @@ You can add multiple roles to a single block or phrase by separating each role n
 I'm a block with an assigned role!
 \----
 ----
+
+=== Inline Roles for Editions, Versions, and Deprecation
+
+Couchbase Documentation created inline page roles for marking sections of documentation as deprecated, for a specific Couchbase Server version, or for marking sections as applying to a specific product edition - similar to <<page-edition,the :page-edition: attribute>>. 
+
+You can use the following inline roles to mark sections of text in your documentation: 
+
+|==== 
+| Role | Example 
+
+a|
+[source,asciidoc]
+----
+[.edition]#{enterprise}#
+----
+a| [.edition]#{enterprise}# 
+
+This text applies to Couchbase Server Enterprise Edition 
+
+a| 
+[source,asciidoc]
+----
+[.edition]#{community}#
+----
+a| [.edition]#{community}# 
+
+This text applies to Couchbase Server Community Edition 
+
+a| 
+[source,asciidoc]
+----
+[.status]#Couchbase Server x.x.x#
+----
+a| [.status]#Couchbase Server 7.6.2#
+
+This text applies to Couchbase Server version 7.6.2 
+
+|====
 
 === Page Roles
 

--- a/home/modules/contribute/pages/attributes-and-roles.adoc
+++ b/home/modules/contribute/pages/attributes-and-roles.adoc
@@ -140,6 +140,15 @@ a| [.status]#Couchbase Server 7.6.2#
 
 This text applies to Couchbase Server version 7.6.2 
 
+a| 
+[source,asciidoc]
+----
+[.deprecated]#Deprecated#
+----
+a| [.deprecated]#Deprecated#
+
+This text applies to a deprecated feature 
+
 |====
 
 === Page Roles

--- a/home/modules/contribute/partials/available-attributes.adoc
+++ b/home/modules/contribute/partials/available-attributes.adoc
@@ -64,7 +64,7 @@ For a page in another repository: `:page-aliases:7.6@server:develop:integrations
 
 When linking to a repository that has a version, you must specify which version in that repository redirects to your current page.
 
-| `:page-edition:`
+| [[page-edition]]`:page-edition:`
 | If you're writing content that only applies to a specific edition of Couchbase Server, usually the Enterprise Edition, use the `page-edition` attribute to add a badge to the page that indicates the Edition the content applies to.
 | `page-edition: Enterprise Edition`
 


### PR DESCRIPTION
Adding documentation in the contributors guide around additional page markings for Editions, Versions, and Deprecations. 

Snapshot of preview: 

