### PR TITLE
Moving operator docs

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -46,10 +46,9 @@ site:
     # see https://confluence.issues.couchbase.com/wiki/spaces/DOCS/pages/2963243023/FAQ+how+does+the+top+nav+bar+work
     nav_groups: |
       [
-        { "title": "Server", "startPage": "home::server.adoc", "components": ["server", "enterprise-analytics"] },
+        { "title": "Server", "startPage": "home::server.adoc", "components": ["server", "operator", "enterprise-analytics"] },
         { "title": "Mobile / Edge", "startPage": "home::mobile.adoc", "components": ["couchbase-lite", "couchbase-lite-javascript", "sync-gateway", "couchbase-edge-server"] },
         { "title": "Capella", "startPage": "home::cloud.adoc", "components": ["cloud", "app-services", "ai", "analytics"] },
-        { "title": "Kubernetes Operator", "startPage": "operator::overview.adoc", "components": ["operator"] },
         { "title": "CMOS", "components": ["cmos"] },
         { "title": "Develop", "startPage": "home::developer.adoc",
             "subGroups": [


### PR DESCRIPTION
With the June release we need to make AI Services (Now AI Data Plane) a top level category.

I've been meaning to move Operator docs under Server for a while but I think now is the most needful and opportune moment.

Tested locally.