### PR TITLE
[DOC-14456] Add new connector versions

### DIFF
--- a/antora-playbook.preview.yml
+++ b/antora-playbook.preview.yml
@@ -197,10 +197,13 @@ content:
         - release/3.3
     - url: https://github.com/couchbase/docs-tableau
       branches:
+        - release/2.0
+        - release/1.2
         - release/1.1
         - release/1.0
     - url: https://github.com/couchbase/docs-connectors-power-bi
       branches:
+        - release/1.3
         - release/1.2
         - release/1.1
         - release/1.0

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -164,9 +164,9 @@ content:
   - url: https://github.com/couchbase/docs-spark
     branches: [release/3.5, release/3.3]
   - url: https://github.com/couchbase/docs-tableau
-    branches: [release/1.1, release/1.0]
+    branches: [release/2.0, release/1.2, release/1.1, release/1.0]
   - url: https://github.com/couchbase/docs-connectors-power-bi
-    branches: [release/1.2, release/1.1, release/1.0]
+    branches: [release/1.3, release/1.2, release/1.1, release/1.0]
   - url: https://github.com/couchbase/docs-connectors-superset.git
     branches: [release/1.0]
   - url: https://github.com/couchbase/docs-connectors-talend


### PR DESCRIPTION
Updated the playbook to add new versions for connector docs - Power BI and Tableau. 