### PR TITLE
DOC-14435 AI IA update and MCP

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -56,8 +56,11 @@ site:
           },
           { "title": "Capella",
             "startPage": "home::cloud.adoc",
-            "components": ["cloud", "app-services", "ai", "analytics"],
+            "components": ["cloud", "app-services", "analytics"],
             "expandHeaderLevels": 1 },
+          { "title": "AI Data Plane",
+            "startPage": "ai:get-started:intro.adoc", 
+            "components": ["ai", "ai-mcp"] },
           { "title": "Develop",
             "startPage": "home::developer.adoc",
               "subGroups": [
@@ -133,6 +136,9 @@ content:
     # see under Server section below for enterprise-analytics and legacy analytics
 
   - url: https://github.com/couchbaselabs/docs-ai
+    start_paths:
+      - .
+      - mcp-server
     branches: [main]
 
     # Couchbase Autonomous Kubernetes Operator


### PR DESCRIPTION
Create a new "AI Data Plane" top nav.

Move `ai` into this top nav
Add `mcp-server`

Also add start_paths for `docs-ai` repo: this requires the https://github.com/couchbaselabs/docs-ai/compare/DOC-14435-mcp-server-landing-page branch to be merged in